### PR TITLE
Test suite/python installation

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Run Tests
         run: |
-          CWD=$(pwd) && export PYTHONPATH="${CWD}/python":$PYTHONPATH
+          cd python && pip install -e . && cd ../
           cd build
           ctest -j1 --output-on-failure

--- a/GX-TimeFrequency/tests/test_minimax/test_minimax.py
+++ b/GX-TimeFrequency/tests/test_minimax/test_minimax.py
@@ -3,14 +3,14 @@ Minimax frequency grid regression tests
 
 Run from GreenX's root:
 
-pytest -s GX-TimeFrequency/tests/test_minimax/test_minimax.py --root <GREENX_ROOT> --binary <MINIMAX_TEST.EXE>
+pytest -s GX-TimeFrequency/tests/test_minimax/test_minimax.py --root <GREENX_ROOT> --binary path/to/<MINIMAX_TEST.EXE>
 
 """
 import pytest
 import numpy as np
 from pathlib import Path
 
-from python.run import BinaryRunner, BuildType
+from pygreenx.run import BinaryRunner, BuildType
 
 
 @pytest.fixture(scope="session")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,54 @@
-## GreenX library - prepared within Work Package 2 of the NOMAD Center of Excellence 
+# GreenX Library 
 
-This project is a shared repository for the development of the GreenX library,
-related to work package 2 of the NOMAD Center of Excellence.
+The Green X library is developed under Work Package 2 of the NOMAD Center of Excellence. 
 
-See the GreenX document for the structure of the library (to be made available in due time). The subdirectories reflect in part the structure of the library.
+## Installation
+
+Green X has been designed as a collection of libraries, which can be built relatively 
+independently of one another. To build the whole suite of Green X libraries from the source 
+you need to have a Fortran compiler supporting Fortran 2008, and one of the supported build 
+systems:
+
+* cmake version 3.0.2 or newer, with a build-system backend, i.e. make
+
+**Building with CMake**   
+
+To build all libraries, set up a build directory:
+
+```bash
+mkdir build 
+```
+
+Change to the directory and run cmake configuration:
+
+```bash
+cmake ../
+```
+
+If all requirements are found, build and install the project:
+
+ ```bash
+make -j
+make install 
+ ```
+
+**Running the Tests** 
+
+GreenX uses pytest as its regression testing framework, in conjunction with 
+some custom python modules. First, one must ensure that the python utilities
+are installed. From the GreenX root directory:
+
+```bash
+cd python
+pip install -e .
+```
+
+The test suite can now be run with CMake's ctest command:
+
+ ```bash
+cd build
+ctest
+ ```
+
+## Usage
+TODO Document 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ cd python
 pip install -e .
 ```
 
+One notes that the user may wish to change the scope of `pip install` to the
+Python user install directory of their platform. Typically `~/.local/`. This
+can be achieved with:
+
+```bash
+pip install --user -e .
+```
+
+unless working in a virtual environment, in which case it is not required.  
+
 The test suite can now be run with CMake's ctest command:
 
  ```bash

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,57 @@
+# pygreenx
+*pygreenx* is intended to be a collection of scripts to facilitate the testing and use of the GreenX library.
+
+## Installation
+*pygreenx* can be installed from the`greenX/python` directory with:
+
+```bash
+pip install -e .
+```
+
+and is required to run GreenX's test suite locally. 
+
+# Information For Developers
+
+## External Package Dependencies
+If a new external dependency is introduced to the package, this also requires adding to `setup.py` such that pip is aware 
+of the new dependency.
+
+## Basic File Structure 
+In general, modules should begin with a docstring giving an overview of the module's purpose. External python
+libraries should then be imported, followed by a space, then local modules belonging to *pygreenx*.
+
+```angular2html
+"""
+Functions that operate on lattice vectors 
+"""
+import numpy as np
+
+from .maths.math_utils import triple_product
+```
+This may change in the future in favour of loading modules in `__init__.py`. 
+
+## Code Formatting 
+
+We are currently favouring [yapf](https://github.com/google/yapf) formatter, which by default applies PEP8 formatting to 
+the code, however any formatter that applies the PEP8 standard is sufficient. 
+
+## Documentation 
+
+### Writing Documentation
+All functions and classes should be documented. The favoured docstring is *reStructuredText*:
+
+```angular2html
+class SimpleEquation:
+   def demo(self, a: int, b: int, c: int) -> list:
+    """
+    Function definition
+
+    :param int a: quadratic coefficient
+    :param int b: linear coefficient 
+    :param c: free term
+    :type c: int
+    :return list y: Function values   
+    """
+```
+where the type can be specified in the `param` description, or separately using the `type` tag. For more details on the
+documentation syntax, please refer to this [link](https://devguide.python.org/documenting/).

--- a/python/pygreenx/run.py
+++ b/python/pygreenx/run.py
@@ -1,5 +1,5 @@
 """
-Module to run executable
+Module to run an executable
 """
 import os
 import pathlib

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = pygreenx
+description = Python tools and API for the GreenX library
+author = Alexander Buccheri # Add all contributors
+license = Apache 2
+platforms = unix, linux, osx
+version = 0.0.1
+
+[options]
+packages = pygreenx
+python_requires = >=3.7
+install_requires =
+    numpy>=1.18.0
+    pytest>=5.4.0
+package_dir =
+    =.

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
Closes issue #16 by making the python utilities installable. 

This seems preferable over updating the PYTHONPATH variable per test, in the CMakeLists.txt.

The CI actions script has not been updated. If the CI fails, I'll do that prior to merging 