### PR TITLE
Disable Analytic Continuation Unit Tests When Zofu Not Present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ add_subdirectory(GX-common)
 add_subdirectory(GX-TimeFrequency)
 
 # Documentation
-option(ENABLE_DOCS "Enable documentation" ON)
+option(ENABLE_DOCS "Enable documentation" OFF)
 if (${ENABLE_DOCS})
     find_program(DOXYGEN doxygen REQUIRED)
     message("-- Doxygen documentation support enabled.")

--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -37,16 +37,18 @@ install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
 # -----------------------------------------------
 # Unit Testing Set-up
 # -----------------------------------------------
+if (${ENABLE_UNITTESTS})
+    # Create a directory in the build folder to place generated test drivers and binaries
+    set(UNIT_TEST_DIR "${PROJECT_BINARY_DIR}/unit_tests/analytic-continuation")
+    file(MAKE_DIRECTORY ${UNIT_TEST_DIR})
+    message("-- Analytic continuation unit tests written to: ${UNIT_TEST_DIR}")
 
-# Create a directory in the build folder to place generated test drivers and binaries
-set(UNIT_TEST_DIR "${PROJECT_BINARY_DIR}/unit_tests/analytic-continuation")
-file(MAKE_DIRECTORY ${UNIT_TEST_DIR})
-message("-- Analytic continuation unit tests written to: ${UNIT_TEST_DIR}")
+    # Libraries on which the unit tests depend
+    set(LIBS_FOR_UNIT_TESTS LibGXAC)
 
-# Libraries on which the unit tests depend
-set(LIBS_FOR_UNIT_TESTS LibGXAC)
+    # For unit tests for many modules, put this in a loop
+    create_unit_test_executable(TARGET_TEST_DIR ${UNIT_TEST_DIR}
+            TEST_NAME "test_pade_approximant"
+            REQUIRED_LIBS ${LIBS_FOR_UNIT_TESTS})
+endif()
 
-# For unit tests for many modules, put this in a loop
-create_unit_test_executable(TARGET_TEST_DIR ${UNIT_TEST_DIR}
-                            TEST_NAME "test_pade_approximant"
-                            REQUIRED_LIBS ${LIBS_FOR_UNIT_TESTS})


### PR DESCRIPTION
`cmake ../` fails if the user does not have Zofu unit testing framework installed. This is unintentional, and is solved by adding an if statement to the unit testing section of the _analytic-continuation_ `CMakeLists.txt`

Additionally, build documentation default is changed to OFF, such that Oxygen is not a hard requirement.