### PR TITLE
Refactor Bare Cosine Changes

### DIFF
--- a/GX-TimeFrequency/src/minimax_grids.F90
+++ b/GX-TimeFrequency/src/minimax_grids.F90
@@ -71,11 +71,11 @@ contains
   !! @param[out] max_errors: Max error for the three kind of transforms (same order as previous args)
   !! @param[out] cosft_duality_error. Max_{ij} |AB - I| where A and B are the cosft_wt and cosft_tw matrices.
   !! @param[out] ierr: Exit status
-  !! @param[out] bare_cossine_weights: if true, cosft/sinft weights are not multiplied by cos/sin term, optional
+  !! @param[in] bare_sin_weights: If true, sinft weights are not multiplied by sin term, optional.
   subroutine gx_minimax_grid(num_points, e_min, e_max, &
        tau_points, tau_weights, omega_points, omega_weights, &
        cosft_wt, cosft_tw, sinft_wt, &
-       max_errors, cosft_duality_error, ierr, bare_cossine_weights)
+       max_errors, cosft_duality_error, ierr, bare_sin_weights)
 
     integer, intent(in)                               :: num_points
     real(kind=dp), intent(in)                         :: e_min, e_max
@@ -86,11 +86,11 @@ contains
     real(kind=dp), allocatable, dimension(:, :), &
          intent(out)                                  :: cosft_wt, cosft_tw, sinft_wt
     real(kind=dp), intent(out)                        :: max_errors(3), cosft_duality_error
-    logical, intent(in), optional                     :: bare_cossine_weights
+    logical, intent(in), optional                     :: bare_sin_weights
     integer, intent(out)                              :: ierr
 
     ! Internal variables
-    logical                                           :: my_bare_cossine_weights
+    logical                                           :: my_bare_sin_weights
     integer, parameter                                :: cos_t_to_cos_w = 1
     integer, parameter                                :: cos_w_to_cos_t = 2
     integer, parameter                                :: sin_t_to_sin_w = 3
@@ -98,15 +98,13 @@ contains
     real(kind=dp)                                     :: e_range, scaling
     real(kind=dp), dimension(:), allocatable          :: x_tw
     real(kind=dp), dimension(:, :), allocatable       :: mat
-    real(kind=dp), dimension(:, :), allocatable       :: tmp_cosft_wt, tmp_cosft_tw
 
-    my_bare_cossine_weights = .false.
-    if (present(bare_cossine_weights)) then
-      if(bare_cossine_weights) my_bare_cossine_weights = .true.
+    my_bare_sin_weights = .false.
+    if (present(bare_sin_weights)) then
+      my_bare_sin_weights = bare_sin_weights
     endif
 
-    ! Begin work
-    e_range = e_max/e_min   
+    e_range = e_max / e_min
     ierr = 0
 
     ! Allocations
@@ -146,8 +144,6 @@ contains
     allocate (cosft_wt(num_points, num_points))
     allocate (cosft_tw(num_points, num_points))
     allocate (sinft_wt(num_points, num_points))
-    allocate (tmp_cosft_wt(num_points, num_points))
-    allocate (tmp_cosft_tw(num_points, num_points))
 
     ! get the weights for the cosine transform W^c(it) -> W^c(iw)
     call get_transformation_weights(num_points, tau_points, omega_points, cosft_wt, e_min, e_max, &
@@ -166,29 +162,24 @@ contains
 
     ! Compute the actual weights used for the inhomogeneous cosine/ FT and check whether
     ! the two matrices for the forward/backward transform are the inverse of each other.
-    if(.not.my_bare_cossine_weights) then
-      do j_point = 1, num_points
-         do i_point = 1, num_points
-            cosft_wt(j_point, i_point) = cosft_wt(j_point, i_point)*cos(tau_points(i_point)*omega_points(j_point))
-            cosft_tw(i_point, j_point) = cosft_tw(i_point, j_point)*cos(tau_points(i_point)*omega_points(j_point))
-            sinft_wt(j_point, i_point) = sinft_wt(j_point, i_point)*sin(tau_points(i_point)*omega_points(j_point))
-         end do
-      end do
-    else
-      do j_point = 1, num_points
-         do i_point = 1, num_points
-            tmp_cosft_wt(j_point, i_point) = cosft_wt(j_point, i_point)*cos(tau_points(i_point)*omega_points(j_point))
-            tmp_cosft_tw(i_point, j_point) = cosft_tw(i_point, j_point)*cos(tau_points(i_point)*omega_points(j_point))
-         end do
-      end do
+    do j_point = 1, num_points
+        do i_point = 1, num_points
+            cosft_wt(j_point, i_point) = cosft_wt(j_point, i_point) * cos(tau_points(i_point) * omega_points(j_point))
+            cosft_tw(i_point, j_point) = cosft_tw(i_point, j_point) * cos(tau_points(i_point) * omega_points(j_point))
+        end do
+    end do
+
+    if (.not. my_bare_sin_weights) then
+        do j_point = 1, num_points
+            do i_point = 1, num_points
+                sinft_wt(j_point, i_point) = sinft_wt(j_point, i_point) * sin(tau_points(i_point) * omega_points(j_point))
+            end do
+        end do
     end if
 
     allocate (mat(num_points, num_points))
-    if(.not.my_bare_cossine_weights) then
-      mat(:,:) = matmul(cosft_wt, cosft_tw)
-    else
-      mat(:,:) = matmul(tmp_cosft_wt, tmp_cosft_tw)
-    endif
+    mat(:,:) = matmul(cosft_wt, cosft_tw)
+
     do i_point = 1, num_points
        mat(i_point, i_point) = mat(i_point, i_point) - 1.0_dp
     end do
@@ -196,7 +187,6 @@ contains
 
     deallocate (mat)
     deallocate (x_tw)
-    deallocate (tmp_cosft_wt,tmp_cosft_tw)
 
   end subroutine gx_minimax_grid
 


### PR DESCRIPTION
The MR #34 was merged too quickly, without proper review.  Some small but meaningful changes:

* cossine should be spelt cossine
* The prior code was confusing because the option was defined as `bare_cossine`, however it was the sin term where the weights were not being multiplied. Please correct me if I have misunderstood the nomenclature
* The use of tmp arrays was completely unnecessary as far as I could tell, so I've removed them.

TODO 

- [ ] One could also take this opportunity to move blas interfaces to a more appropriate location
