### PR TITLE
DOI correction

### DIFF
--- a/JOSS/refs.bib
+++ b/JOSS/refs.bib
@@ -558,7 +558,7 @@ TITLE={{Low-Order Scaling Quasiparticle Self-Consistent GW for Molecules}},
 JOURNAL={Frontiers in Chemistry},
 VOLUME={9},
 pages={736591},
-doi = {10.3389%2Ffchem.2021.736591},
+doi = {10.3389/fchem.2021.736591},
 YEAR={2021},
 }
 @article{foerster2023twocomponent,


### PR DESCRIPTION
In this MR correct the misspelled DOI in the JOSS manuscript.  