### PR TITLE
add information to website

### DIFF
--- a/docs/gx_time_frequency.md
+++ b/docs/gx_time_frequency.md
@@ -4,22 +4,27 @@ title: Time-Frequency component
 tagline: GreenX Time-Frequency
 description: Time-Frequency component
 ---
+# General
+
+The time-frequency component of GreenX provides minimax time and frequency grids and the corresponding quadrature weights for the numerical evaluation of time and frequency integrals as well as the weights for Fourier transforms between time and frequency grids. The minimax grids are primarily relevant for low-scaling RPA and GW algorithms, which use the [space-time method](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.74.1827). However, the compact minimax frequency grids also reduce the computational prefactor in RPA codes with conventional scaling. In addition, the time grids can be employed in Laplace-transformed direct MP2 (LT-dMP2) calculations.
 
 # Benchmarks
 
-## CH<sub>4</sub> RPA
+## Correlation energy from conventional RPA for CH<sub>4</sub>
 
-In this test, we evaluate the RPA total energy of CH4 using a Gauss-Legendre grid, a modified Gauss-Legendre grid (so 
-far the standard in FHI-aims and abinit), and minimax grids. An accuracy of 10^-6 eV is reached with 10 minimax grid 
-points while the modified Gauss-Legendre grids requires 36 points for this accuracy.
+In this test, we evaluate the RPA total energy of CH4 using a Gauss-Legendre grid, a modified Gauss-Legendre grid (so far the standard in FHI-aims and abinit), and minimax grids. An accuracy of 10^-6 eV is reached with 10 minimax grid points while the modified Gauss-Legendre grids requires 36 points for this accuracy.
 
 [CH4 benchmark](./img/ch4_bench.png)
 
-Error differences of the total RPA energy [eV] of methane calculated using the Gauss-Legendre, modified Gauss-Legendre 
-and minimax imaginary frequency grid points. These differences were calculated with respect to the lowest RPA energy 
-obtained with 34 minimax grid points. The ground state energy was calculated using the PBE exchange correlation 
-functional in combination of the Tier2 basis set. The global resolution of identity (RI-V) approach was used for the 
-calculation of the exact exchange and RPA correlation energy. The auxiliary basis functions for the RI-V method were 
-generated automatically on the fly.
+Error differences of the total RPA energy [eV] of methane calculated using the Gauss-Legendre, modified Gauss-Legendre and minimax imaginary frequency grid points. These differences were calculated with respect to the lowest RPA energy obtained with 34 minimax grid points. The ground state energy was calculated using the PBE exchange correlation functional in combination of the Tier2 basis set. The global resolution of identity (RI-V) approach was used for the 
+calculation of the exact exchange and RPA correlation energy. The auxiliary basis functions for the RI-V method were generated automatically on the fly.
+
+## GW100
+
+Some minimax grids published in GreenX were used in previous work, e.g., DOI:[110.1021/acs.jctc.0c01282](https://pubs.acs.org/doi/10.1021/acs.jctc.0c01282). In this reference, a subset of the GreenX authors performed benchmark tests for the low-scaling GW implementation in the CP2K program package for different grid sizes using the [GW100 test set](https://pubs.acs.org/doi/10.1021/acs.jctc.5b00453). The authors presented benchmark results for grids with 10, 20, 26,28, 30, 32 and 34 grid points and showed that the mean absolute deviations (MADs) compared to a conventional-scaling GW code with converged out grid settings systematically improve with the number of minimax grid points reaching MADs < 10 meVs.
+
+## Further tests
+
+A paper with comprehensive tests on molecules and periodic systems is in preparation. 
 
 ---

--- a/docs/gx_time_frequency.md
+++ b/docs/gx_time_frequency.md
@@ -14,7 +14,7 @@ The time-frequency component of GreenX provides minimax time and frequency grids
 
 In this test, we evaluate the RPA total energy of CH4 using a Gauss-Legendre grid, a modified Gauss-Legendre grid (so far the standard in FHI-aims and abinit), and minimax grids. An accuracy of 10^-6 eV is reached with 10 minimax grid points while the modified Gauss-Legendre grids requires 36 points for this accuracy.
 
-[CH4 benchmark](./img/ch4_bench.png)
+![CH4 benchmark](./img/ch4_bench.png)
 
 Error differences of the total RPA energy [eV] of methane calculated using the Gauss-Legendre, modified Gauss-Legendre and minimax imaginary frequency grid points. These differences were calculated with respect to the lowest RPA energy obtained with 34 minimax grid points. The ground state energy was calculated using the PBE exchange correlation functional in combination of the Tier2 basis set. The global resolution of identity (RI-V) approach was used for the 
 calculation of the exact exchange and RPA correlation energy. The auxiliary basis functions for the RI-V method were generated automatically on the fly.


### PR DESCRIPTION
added information to published GW100 benchmark and a general description of the time-frequency component on our github page