### PR TITLE
Solves remaining issues in JOSS 5570#issuecomment-1670074739

### DIFF
--- a/GX-TimeFrequency/README.md
+++ b/GX-TimeFrequency/README.md
@@ -35,42 +35,7 @@ pytest -s test_name.py
 
 ## Calling the MiniMax Library
 
-The minimax grid generation is called like so:
-
-```fortran
-use gx_minimax, only: gx_minimax_grid
-
-! Declarations
-integer :: n_mesh_points
-real(dp) :: e_transition_min, e_transition_max
-real(dp), allocatable :: tau_mesh(:), tau_weights(:)
-real(dp), allocatable :: freq_mesh(:), freq_weights(:)
-real(dp), allocatable :: cos_tau_to_freq_weights(:, :)
-real(dp), allocatable :: cos_freq_to_tau_weights(:, :)
-real(dp), allocatable :: sinft_tau_to_freq_weights(:, :)
-real(dp) :: max_errors(3)
-real(dp) :: cosft_duality_error
-integer :: ierr
-
-call gx_minimax_grid(n_mesh_points, e_transition_min, e_transition_max, &
-                     tau_mesh, tau_weights, &
-                     freq_mesh, freq_weights, &
-                     cos_tau_to_freq_weights, cos_freq_to_tau_weights, &
-                     sinft_tau_to_freq_weights, &
-                     max_errors, cosft_duality_error, ierr)
-```
-
-For a description of the variables, please consult `src/minimax_grids.F90`.
-For an example of how to call `gx_minimax_grid`, please consult `test/test_gx_minimax_grid.f90`.
-
-Additionally, one can also call a utility routine to query whether the 
-number of imaginary-time points has a corresponding grid tabulation:
-
-```fortran
-use api_utilites, only: gx_check_ntau, gx_get_error_message
-
-call gx_check_ntau(ntau, msg, ierr)
-```
+Information on how to use the library is always up-to-date on the [GreenX website](nomad-coe.github.io/greenX/).
 
 ## For Developers
 


### PR DESCRIPTION
This merge request solves the following issues raised by the editor (here)[https://github.com/openjournals/joss-reviews/issues/5570#issuecomment-1670074739]. The points are repeated for convenience:

- Do you plan to update both forms of docs? This seems it might get a bit difficult to maintain and that there might be divergence. Users need to be clear about what is the master docs.

- The GH pages docs refer to an exascale library: perhaps wording such as exascale-ready library or exascale-optimised might be better - as the library itself is not exascale.
 
- Returning to a point made at the start of the review process: currently the paper is too long and goes into too deep a level of mathematical detail. I suggest you move the mathematical section to the online documentation. Even with this section removed from the paper you will pushing the allowed word limit I think. Detailed docs are meant to be hosted online, with the paper acting as a short 1/2-page advert for the code.

- I noticed slight inconsistencies with terminology. In the section required input and output of the library you make several references to a library when I think you are referring to the time-frequency component specifically. If so, this needs re-wording so that there is no confusion between the two.
