### PR TITLE
Options for specific component installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,6 @@ if (NOT pygreenx_FOUND)
   message("-- pygreenx is required for application testing. To install it, cd <PROJECTROOT>/python and run `pip install -e .`")
 endif ()
 
-# Optional multiple precision arithmetic
-option(ENABLE_GNU_GMP "Enable the GNU GMP library for multiple precision arithmetic" ON)
-if (${ENABLE_GNU_GMP})
-  find_package(GMPXX)
-endif()
-
 # Optional unit testing lib
 option(ENABLE_UNITTESTS "Enable GreenX Unit Testing" ON)
 if (${ENABLE_UNITTESTS})
@@ -99,10 +93,25 @@ endif()
 
 # Our library directories
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
-add_subdirectory(GX-AnalyticContinuation)
 add_subdirectory(GX-common)
-add_subdirectory(GX-TimeFrequency)
-add_subdirectory(GX-LocalizedBasis)
+option(AC_COMPONENT "Enable the Analytical Continuation component" ON)
+if (${AC_COMPONENT})
+   # Optional multiple precision arithmetic
+   option(ENABLE_GNU_GMP "Enable the GNU GMP library for multiple precision arithmetic" ON)
+   if (${ENABLE_GNU_GMP})
+      find_package(GMPXX)
+   endif()
+   add_subdirectory(GX-AnalyticContinuation)
+endif()
+option(MINIMAX_COMPONENT "Enable the minimax time-frequency grids component" ON)
+if (${MINIMAX_COMPONENT})
+   add_subdirectory(GX-TimeFrequency)
+endif ()
+
+option (LBASIS_COMPONENT "Enable the localized basis component" ON) 
+if (${LBASIS_COMPONENT})
+   add_subdirectory(GX-LocalizedBasis)
+endif()
 
 # Elements to compile the libraries inside submodules
 option(COMPILE_SUBMODULES "Compile GreenX component contained inside submodules" ON)
@@ -135,21 +144,24 @@ if (${COMPILE_SUBMODULES})
 endif()
 
 # Install libpaw
-set(LIBPAW_SOURCE "${PROJECT_SOURCE_DIR}/GX-PAW/")
-ExternalProject_Add(LIBPAW
-    SOURCE_DIR ${LIBPAW_SOURCE}
-    PREFIX ${LIBPAW_SOURCE}
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-               -DCMAKE_Fortran_COMPILER=gfortran
-    BUILD_COMMAND make -j 1
-    INSTALL_COMMAND make install)
-# Now properly link our LIBPAW installation from the LIBPAW install directory to the common one from GreenX
-set(LIBPAW_INSTALL_DIR "${LIBPAW_SOURCE}/libpaw-greenx")
-install(FILES ${LIBPAW_INSTALL_DIR}/lib/libabinit_common.a DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${LIBPAW_INSTALL_DIR}/lib/libpaw.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(DIRECTORY ${LIBPAW_INSTALL_DIR}/include/
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/modules/
-        FILES_MATCHING PATTERN "*d")
+option(PAW_COMPONENT "Enable the PAW component" ON)
+if (${PAW_COMPONENT})
+   set(LIBPAW_SOURCE "${PROJECT_SOURCE_DIR}/GX-PAW/")
+   ExternalProject_Add(LIBPAW
+      SOURCE_DIR ${LIBPAW_SOURCE}
+      PREFIX ${LIBPAW_SOURCE}
+      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                 -DCMAKE_Fortran_COMPILER=gfortran
+      BUILD_COMMAND make -j 1
+      INSTALL_COMMAND make install)
+   # Now properly link our LIBPAW installation from the LIBPAW install directory to the common one from GreenX
+   set(LIBPAW_INSTALL_DIR "${LIBPAW_SOURCE}/libpaw-greenx")
+   install(FILES ${LIBPAW_INSTALL_DIR}/lib/libabinit_common.a DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+   install(FILES ${LIBPAW_INSTALL_DIR}/lib/libpaw.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+   install(DIRECTORY ${LIBPAW_INSTALL_DIR}/include/
+           DESTINATION ${CMAKE_INSTALL_PREFIX}/include/modules/
+           FILES_MATCHING PATTERN "*d")
+endif()
 
 # Documentation
 option(ENABLE_DOCS "Enable documentation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if (NOT pygreenx_FOUND)
 endif ()
 
 # Optional unit testing lib
-option(ENABLE_UNITTESTS "Enable GreenX Unit Testing" ON)
+option(ENABLE_UNITTESTS "Enable GreenX Unit Testing" OFF)
 if (${ENABLE_UNITTESTS})
   # Build zofu
   ExternalProject_Add(

--- a/README.md
+++ b/README.md
@@ -53,12 +53,54 @@ configure with:
 cmake ../ -DBUILD_SHARED_LIBS=OFF
 ```
 
+Specific shared libraries can be disable, e.g to disable the Projector-Augmented Wave (PAW) component of GreenX, run CMake configure with: 
+
+```bash
+cmake ../ -DPAW_COMPONENT=OFF
+```
+
+Available options to disable one or more components
+
+| Component                              | CMake configure                    |
+|----------------------------------------|------------------------------------|
+| Analytical Continuation component      | `cmake .. -DAC_COMPONENT=OFF`      |
+| Minimax Time-Frequency grids component | `cmake .. -DMINIMAX_COMPONENT=OFF` |
+| Localized Basis component              | `cmake .. -DLBASIS_COMPONENT=OFF`  |
+| Projector-Augmented Wave component     | `cmake .. -DPAW_COMPONENT=OFF`     |
+
+GreenX uses GNU Multiple Precision Arithmetic Library by default in the Analytical Continuation component, you can disable it without any harm by runing CMake configure with:
+
+```bash
+cmake ../ -DENABLE_GNU_GMP=OFF
+```
+
+GreenX uses submodules and they are built by default. You can obtained them by executing:
+
+```bash
+git submodule update --init --recursive
+```
+
+To build GreenX without the submodules, one can configure with:
+
+```bash
+cmake ../ -DCOMPILE_SUBMODULES=OFF
+```
+
 If all requirements are found, build and install the project:
 
  ```bash
 make -j
 make install 
  ```
+
+Minimal example to build and install only the Time-Frequency component of GreenX:
+
+ ```bash
+cmake .. -DAC_COMPONENT=OFF -DLBASIS_COMPONENT=OFF -DPAW_COMPONENT=OFF -DCOMPILE_SUBMODULES=OFF
+make -j
+make install
+ ```
+
 
 ## Running the Tests
 


### PR DESCRIPTION
I have created _option CMake flags_ for every available component in the library.  The CMake options permits a clean build and installation of one o more components of the library. It also controls the build and installation of the sub-modules. In principle nothing has changed compared to the current version of the library. The `README` contains all the documentation related to this implementation.