### PR TITLE
Change documentation and unit_tests option flags

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake -DENABLE_UNITTESTS=ON \
+          cmake -DENABLE_GREENX_UNIT_TESTS=ON \
                 -DZOFU_PATH=/home/runner/work/greenX/greenX/external/zofu/install \
                 -DGMPXX_INCLUDE_DIR=/usr/include/ \
                 -DGMPXX_LIBRARY=/usr/lib/x86_64-linux-gnu/libgmpxx.so ../

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,30 +47,32 @@ include(ExternalProject)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
-# Python required for application testing
-include(cmake/python3.cmake)
+option(ENABLE_GREENX_CTEST "Enable GreenX CTest" ON)
+if (${ENABLE_GREENX_CTEST})
+   # Python required for application testing
+   include(cmake/python3.cmake)
+   find_package(Python3 3.7 COMPONENTS Interpreter Development)
+   if (Python3_FOUND)
+      message("-- Python 3 interpreter version: " ${Python3_VERSION})
+   else()
+      message("-- Python 3 interpreter not found")
+   endif()
 
-find_package(Python3 3.7 COMPONENTS Interpreter Development)
-if(Python3_FOUND)
-  message("-- Python 3 interpreter version: " ${Python3_VERSION})
-else()
-  message("-- Python 3 interpreter not found")
-endif()
+   # Enable ctest
+   enable_testing()
 
-# Enable ctest
-enable_testing()
-
-# Application test python module
-# Note, pygreenx dependencies should be handled pygreenx
-# pygreenx version specified in its setup.cfg
-find_python_module(pygreenx VERSION 0.0.1)
-if (NOT pygreenx_FOUND)
-  message("-- pygreenx is required for application testing. To install it, cd <PROJECTROOT>/python and run `pip install -e .`")
-endif ()
+   # Application test python module
+   # Note, pygreenx dependencies should be handled pygreenx
+   # pygreenx version specified in its setup.cfg
+   find_python_module(pygreenx VERSION 0.0.1)
+   if (NOT pygreenx_FOUND)
+      message("-- pygreenx is required for application testing. To install it, cd <PROJECTROOT>/python and run `pip install -e .`")
+   endif ()
+endif()   
 
 # Optional unit testing lib
-option(ENABLE_UNITTESTS "Enable GreenX Unit Testing" OFF)
-if (${ENABLE_UNITTESTS})
+option(ENABLE_GREENX_UNIT_TESTS "Enable GreenX Unit Testing" OFF)
+if (${ENABLE_GREENX_UNIT_TESTS})
   # Build zofu
   ExternalProject_Add(
     zofu
@@ -164,8 +166,8 @@ if (${PAW_COMPONENT})
 endif()
 
 # Documentation
-option(ENABLE_DOCS "Enable documentation" OFF)
-if (${ENABLE_DOCS})
+option(ENABLE_GREENX_DOCS "Enable documentation" OFF)
+if (${ENABLE_GREENX_DOCS})
   find_program(DOXYGEN doxygen REQUIRED)
   message("-- Doxygen documentation support enabled.")
   set(doxy_output "documentation")

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ GreenX is documented using Doxygen, and documentation support is disabled by
 default. To enable CMake looking for Doxygen, configure with:
 
 ```bash
-cmake ../ -DENABLE_DOCS=ON
+cmake ../ -DENABLE_GREENX_DOCS=ON
 ```
 
 To build the document, type in the build directory:
@@ -179,7 +179,7 @@ make install
 GreenX can be built with unit-testing enabled using:
 
 ```bash
-cmake -DENABLE_UNITTESTS=ON -DZOFU_PATH=${GX_ROOT}/external/zofu/install ../
+cmake -DENABLE_GREENX_UNIT_TESTS=ON -DZOFU_PATH=${GX_ROOT}/external/zofu/install ../
 ```
 
 Unit tests are run with the application tests, using ctest. Simply type `ctest`


### PR DESCRIPTION
I have changed the _CMake option flags_ to build the UNIT_TESTS and DOCS with an explicit specification of GREENX. This is done to avoid the possible future conflicts of the _CMake option_ with the possible host code.  I also have added a _CMake option_ to disable the CTests (This option is not discussed in the README it was created for safety reason since `ctest` is ON by default. My implementations do not change actual behavior the GreenX.