### PR TITLE
Fix zofu install

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -37,25 +37,11 @@ jobs:
       - name: Install blas, lapack and other dependencies
         run: sudo apt-get install libblas-dev liblapack-dev doxygen libgmp10 libgmpxx4ldbl libgmp-dev libopenblas-dev
 
-      - name: Install Zofu Test Framework
-        run: |
-          mkdir -p external && cd external
-          git clone https://github.com/acroucher/zofu.git
-          mkdir zofu/build && cd zofu/build
-          cmake \
-             -DCMAKE_BUILD_TYPE=release \
-             -DCMAKE_INSTALL_PREFIX=/home/runner/work/greenX/greenX/external/zofu/install \
-             -DZOFU_FORTRAN_MODULE_INSTALL_DIR:PATH=include \
-             ..
-          make -j 4
-          make install
-
       - name: Build
         run: |
           mkdir -p build
           cd build
           cmake -DENABLE_GREENX_UNIT_TESTS=ON \
-                -DZOFU_PATH=/home/runner/work/greenX/greenX/external/zofu/install \
                 -DGMPXX_INCLUDE_DIR=/usr/include/ \
                 -DGMPXX_LIBRARY=/usr/lib/x86_64-linux-gnu/libgmpxx.so ../
           make -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,23 +73,9 @@ endif()
 # Optional unit testing lib
 option(ENABLE_GREENX_UNIT_TESTS "Enable GreenX Unit Testing" OFF)
 if (${ENABLE_GREENX_UNIT_TESTS})
-  # Build zofu
-  ExternalProject_Add(
-    zofu
-    PREFIX ${CMAKE_BINARY_DIR}/external/zofu  # Directory to download and build the project
-    GIT_REPOSITORY https://github.com/acroucher/zofu.git  # GitHub repository URL
-    GIT_TAG master  # Specific branch, tag, or commit
-    CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=release
-        -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}/external/zofu/install
-        -DZOFU_FORTRAN_MODULE_INSTALL_DIR:PATH=include
-    UPDATE_COMMAND ""  # Leave this empty to avoid re-downloading on every build
-    TEST_COMMAND ""  # No test step
-    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
-  )
   # Function for generating unit test executables (assumes Zofu)
   include(cmake/unit_test_functions.cmake)
-  # Calling find_package is equivalent to: include(cmake/Findzofu.cmake)
+  # find ZOFU in $ZOFU_PATH or build on the fly
   include(cmake/Findzofu.cmake)
 endif()
 

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -38,5 +38,5 @@ install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
 
 # ensure that zofu is build before GXCommon 
 if (${ZOFU_BUILD_ON_FLY})
-  add_dependencies(GXCommon LibZofu)
+  add_dependencies(GXCommon zofu)
 endif()

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -34,3 +34,9 @@ install(TARGETS GXCommon
 ## CMakeLists.txt
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
         DESTINATION include)
+
+
+# ensure that zofu is build before GXCommon 
+if (${ZOFU_BUILD_ON_FLY})
+  add_dependencies(GXCommon LibZofu)
+endif()

--- a/README.md
+++ b/README.md
@@ -155,12 +155,24 @@ For more information and benchmark examples see also the [GreenX website](https:
 
 ## Unit Testing
 
-### Installing the Unit-Testing Framework
+### Running Unit Tests
 
-Unit tests require the unit-testing framework [Zofu](https://github.com/acroucher/zofu).
-To build Zofu, from GreenX's root (noting that one must define `$GX_ROOT`):
+Unit tests require the unit-testing framework [Zofu](https://github.com/acroucher/zofu). This library is build together with Greenx when `ENABLE_GREENX_UNIT_TESTS=ON`: 
 
-```bash
+```bash 
+cmake -DENABLE_GREENX_UNIT_TESTS=ON ../
+```
+Unit tests are run with the application tests, using ctest. Simply type `ctest`
+in the build directory.
+
+
+### Installing the Unit-Testing Framework manually
+
+It is also possible to compile Zofu manually. To build Zofu, from GreenX's root (noting that one must define `$GX_ROOT`):
+
+```bash 
+
+# building zofu
 mkdir external && cd external
 git clone https://github.com/acroucher/zofu.git
 cd zofu
@@ -172,18 +184,15 @@ cmake \
    ..
 make -j 4
 make install
-```
 
-### Running Unit Tests
-
-GreenX can be built with unit-testing enabled using:
-
-```bash
+# building GreenX 
+cd $GX_ROOT 
+mkdir build && cd build 
 cmake -DENABLE_GREENX_UNIT_TESTS=ON -DZOFU_PATH=${GX_ROOT}/external/zofu/install ../
+make -j 2
+make install
 ```
-
-Unit tests are run with the application tests, using ctest. Simply type `ctest`
-in the build directory.
+Again, typing `ctest` in the GreenX build directory starts the unit tests together with the application tests.
 
 ### Adding Unit Tests
 

--- a/cmake/Findzofu.cmake
+++ b/cmake/Findzofu.cmake
@@ -53,7 +53,7 @@ if (LibZofu)
 else()
   message("-- LibZofu not found")
   # Build zofu at compile time
-  set(ZUFU_BUILD_ON_FLY TRUE) 
+  set(ZOFU_BUILD_ON_FLY TRUE) 
   set(ZOFU_PATH_ROOT "${CMAKE_BINARY_DIR}/external/zofu")
 
   ExternalProject_Add(


### PR DESCRIPTION
**Problem:**
- right now zofu has to be compiled externally and the path is provided to GreenX 
- additionally zofu is compiled as submodule
- but the submodule is not used, instead the externally compiled zofu is used 

**Fix:**
- added conditional use of the zofu submodule
- when ZOFU_PATH is set, the external zofu is used
- when ZOFU_PATH is **not** set, zofu is cloned and compiled as a submodule