### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install Cmake
         run: pip3 install cmake

--- a/.github/workflows/joss-TimeFrequency-pdf.yml
+++ b/.github/workflows/joss-TimeFrequency-pdf.yml
@@ -14,7 +14,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: JOSS/timefrequency/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
github actions had deprecated scripts
- python version in application tests
- deprecated actions/upload-artifact version

updated both, pipeline is working again