### PR TITLE
fix edge case of pade where all function values are 0 

### DIFF
--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -131,3 +131,8 @@ add_test(
         COMMAND pytest -s test_gx_analytic_continuation_symmetry_128bit.py --build-dir ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
 )
+add_test(
+        NAME test_gx_analytic_continuation_reference_0
+        COMMAND pytest -s test_gx_analytic_continuation_reference_0.py --build-dir ${CMAKE_BINARY_DIR}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
+)

--- a/GX-AnalyticContinuation/test/test_gx_analytic_continuation_greedy_128bit.py
+++ b/GX-AnalyticContinuation/test/test_gx_analytic_continuation_greedy_128bit.py
@@ -29,7 +29,7 @@ def fortran_binary(get_binary, greenx_build_root):
 def get_AC_residual_sum(fortran_binary):
     """ run the AC component"""
     # Run test
-    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["greedy", "128", "none"])
+    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["greedy", "128", "none", "normal"])
     results = runner.run()
     assert results.success, f"Execution of {fortran_binary} failed"
 

--- a/GX-AnalyticContinuation/test/test_gx_analytic_continuation_greedy_64bit.py
+++ b/GX-AnalyticContinuation/test/test_gx_analytic_continuation_greedy_64bit.py
@@ -29,7 +29,7 @@ def fortran_binary(get_binary, greenx_build_root):
 def get_AC_residual_sum(fortran_binary):
     """ run the AC component"""
     # Run test
-    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["greedy", "64", "none"])
+    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["greedy", "64", "none", "normal"])
     results = runner.run()
     assert results.success, f"Execution of {fortran_binary} failed"
 

--- a/GX-AnalyticContinuation/test/test_gx_analytic_continuation_no-greedy_128bit.py
+++ b/GX-AnalyticContinuation/test/test_gx_analytic_continuation_no-greedy_128bit.py
@@ -29,7 +29,7 @@ def fortran_binary(get_binary, greenx_build_root):
 def get_AC_residual_sum(fortran_binary):
     """ run the AC component"""
     # Run test
-    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "128", "none"])
+    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "128", "none", "normal"])
     results = runner.run()
     assert results.success, f"Execution of {fortran_binary} failed"
 

--- a/GX-AnalyticContinuation/test/test_gx_analytic_continuation_no-greedy_64bit.py
+++ b/GX-AnalyticContinuation/test/test_gx_analytic_continuation_no-greedy_64bit.py
@@ -29,7 +29,7 @@ def fortran_binary(get_binary, greenx_build_root):
 def get_AC_residual_sum(fortran_binary):
     """ run the AC component"""
     # Run test
-    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "64", "none"])
+    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "64", "none", "normal"])
     results = runner.run()
     assert results.success, f"Execution of {fortran_binary} failed"
 

--- a/GX-AnalyticContinuation/test/test_gx_analytic_continuation_reference_0.py
+++ b/GX-AnalyticContinuation/test/test_gx_analytic_continuation_reference_0.py
@@ -29,7 +29,7 @@ def fortran_binary(get_binary, greenx_build_root):
 def get_AC_residual_sum(fortran_binary):
     """ run the AC component"""
     # Run test
-    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "64", "conjugate", "normal"])
+    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "64", "none", "test_0"])
     results = runner.run()
     assert results.success, f"Execution of {fortran_binary} failed"
 
@@ -41,8 +41,8 @@ def get_AC_residual_sum(fortran_binary):
 
 def test_get_rirs_overlap_error(fortran_binary): 
     """ test the AC component """
-    ref =  0.50958909E-05                         # reference value
+    ref =  0.0                                    # reference value
     res_sum = get_AC_residual_sum(fortran_binary) # comupte actual value
     print(f"comparing ref:{ref}, out:{res_sum}")
-    assert np.allclose(res_sum, ref, atol=1.e-8)
+    assert (res_sum == ref)
 

--- a/GX-AnalyticContinuation/test/test_gx_analytic_continuation_symmetry_128bit.py
+++ b/GX-AnalyticContinuation/test/test_gx_analytic_continuation_symmetry_128bit.py
@@ -29,7 +29,7 @@ def fortran_binary(get_binary, greenx_build_root):
 def get_AC_residual_sum(fortran_binary):
     """ run the AC component"""
     # Run test
-    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "128", "conjugate"])
+    runner = BinaryRunner(fortran_binary, BuildType.serial, args=["no_greedy", "128", "conjugate", "normal"])
     results = runner.run()
     assert results.success, f"Execution of {fortran_binary} failed"
 


### PR DESCRIPTION
# issue:
- segfault occurs when all function values are zero in a call of `create_thiele_pade()`

# fix:
- this case is caught before the pade model is created (by setting an internal flag)
- when the pade model is used with `evaluate_thiele_pade_at()` it returns cmplx(0.0, 0.0) for every value of y

# test:
- added a ctest, that tests this for this issue

# more info:
- a more rigorous approach would be to catch the "devision by 0" on the spot where it occurs
- problem is that this is not straight forward for multiple precision numbers
- therefore the flag is a better option right now to make it consistent between the fortran and the GMP-c++ implementation
