### PR TITLE
Config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,3 +169,15 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     CACHE STRING "Choose the installation directory. Default location is ${default_install_prefix}"
     FORCE)
 endif()
+
+install(
+    EXPORT      greenXTargets
+    NAMESPACE   greenX::
+    FILE        greenXTargets.cmake
+    DESTINATION lib/cmake/greenX
+)
+
+install(
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/greenXConfig.cmake"
+    DESTINATION lib/cmake/greenX
+)

--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -17,7 +17,12 @@ set_target_properties(LibGXAC
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_Fortran_LIB_DIRECTORY}
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_Fortran_LIB_DIRECTORY})
 
-target_include_directories(LibGXAC PUBLIC src/)
+#target_include_directories(LibGXAC PUBLIC src/)
+target_include_directories(LibGXAC
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:include>
+)
 if(GMPXX_FOUND)
   add_definitions(-DGMPXX_FOUND)
   target_sources(LibGXAC PRIVATE src/pade_approximant.f90 src/ComplexGMP.cpp src/Symmetry_pade.cpp src/pade_mp.cpp api/gx_ac.F90)
@@ -33,7 +38,7 @@ endif()
 # -----------------------------------------------
 # Install library
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
-install(TARGETS LibGXAC ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
+install(TARGETS LibGXAC EXPORT greenXTargets ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
@@ -50,8 +55,11 @@ include(../cmake/testFunctions.cmake)
 # Set name of test sub-directory in the build directory
 set(TEST_TARGET_DIR "analytic_continuation")
 
-target_include_directories(LibGXAC PUBLIC test/)
-
+#target_include_directories(LibGXAC PUBLIC test/)
+target_include_directories(LibGXAC
+         PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+)
 # Set pytest conftest for Localized basis library tests
 add_custom_command(
 	TARGET LibGXAC POST_BUILD

--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -55,7 +55,6 @@ include(../cmake/testFunctions.cmake)
 # Set name of test sub-directory in the build directory
 set(TEST_TARGET_DIR "analytic_continuation")
 
-#target_include_directories(LibGXAC PUBLIC test/)
 target_include_directories(LibGXAC
          PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>

--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(LibGXAC
 target_include_directories(LibGXAC
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/modules>
 )
 if(GMPXX_FOUND)
   add_definitions(-DGMPXX_FOUND)

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -71,7 +71,6 @@ include(../cmake/testFunctions.cmake)
 # Set name of test sub-directory in the build directory
 set(TEST_TARGET_DIR "localized_basis")
 
-#target_include_directories(LibGXLBasis PUBLIC test/)
 target_include_directories(LibGXLBasis 
          PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -24,7 +24,16 @@ set_target_properties(LibGXLBasis
         )
 
 # Add include directories to the LibGXMiniMax
-target_include_directories(LibGXLBasis PUBLIC src/ api/)
+#target_include_directories(LibGXLBasis PUBLIC src/ api/)
+target_include_directories(LibGXLBasis 
+    PUBLIC
+        # Build-time includes (point to actual source dirs)
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
+
+        # Install-time includes (point to the location where headers/modules land when installed)
+        $<INSTALL_INTERFACE:include>
+)
 
 # Define source that comprise LibGXLBasis
 target_sources(LibGXLBasis PRIVATE
@@ -43,8 +52,10 @@ target_link_libraries(LibGXLBasis GXCommon ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
 # Install library
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
 install(TARGETS LibGXLBasis
+        EXPORT greenXTargets
         ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+        LIBRARY DESTINATION lib
+)
 
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
@@ -60,7 +71,11 @@ include(../cmake/testFunctions.cmake)
 # Set name of test sub-directory in the build directory
 set(TEST_TARGET_DIR "localized_basis")
 
-target_include_directories(LibGXLBasis PUBLIC test/)
+#target_include_directories(LibGXLBasis PUBLIC test/)
+target_include_directories(LibGXLBasis 
+         PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+)
 
 # Set pytest conftest for Localized basis library tests
 add_custom_command(

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(LibGXLBasis
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
 
         # Install-time includes (point to the location where headers/modules land when installed)
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/modules>
 )
 
 # Define source that comprise LibGXLBasis

--- a/GX-TimeFrequency/CMakeLists.txt
+++ b/GX-TimeFrequency/CMakeLists.txt
@@ -97,7 +97,6 @@ include(../cmake/testFunctions.cmake)
 # Set name of test sub-directory in the build directory
 set(TEST_TARGET_DIR "time-frequency")
 
-#target_include_directories(LibGXMiniMax PUBLIC test/)
 target_include_directories(LibGXMiniMax 
          PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>

--- a/GX-TimeFrequency/CMakeLists.txt
+++ b/GX-TimeFrequency/CMakeLists.txt
@@ -20,8 +20,17 @@ set_target_properties(LibGXMiniMax
         )
 
 # Add include directories to the LibGXMiniMax
-target_include_directories(LibGXMiniMax PUBLIC src/ api/ utilities/)
+#target_include_directories(LibGXMiniMax PUBLIC src/ api/ utilities/)
+target_include_directories(LibGXMiniMax
+    PUBLIC
+        # Build-time includes (point to actual source dirs)
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utilities>
 
+        # Install-time includes (point to the location where headers/modules land when installed)
+        $<INSTALL_INTERFACE:include>
+)
 # Define source that comprise LibGXMiniMax
 target_sources(LibGXMiniMax PRIVATE
         src/gx_common.h
@@ -65,8 +74,10 @@ target_link_libraries(GXTabulateGrids
 # Install library
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
 install(TARGETS LibGXMiniMax
+        EXPORT greenXTargets
         ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+        LIBRARY DESTINATION lib
+)
 
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
@@ -86,7 +97,11 @@ include(../cmake/testFunctions.cmake)
 # Set name of test sub-directory in the build directory
 set(TEST_TARGET_DIR "time-frequency")
 
-target_include_directories(LibGXMiniMax PUBLIC test/)
+#target_include_directories(LibGXMiniMax PUBLIC test/)
+target_include_directories(LibGXMiniMax 
+         PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+)
 
 # Set pytest conftest for Time-Frequency library tests
 add_custom_command(

--- a/GX-TimeFrequency/CMakeLists.txt
+++ b/GX-TimeFrequency/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(LibGXMiniMax
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utilities>
 
         # Install-time includes (point to the location where headers/modules land when installed)
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/modules>
 )
 # Define source that comprise LibGXMiniMax
 target_sources(LibGXMiniMax PRIVATE

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -17,7 +17,7 @@ set_target_properties(GXCommon
 target_include_directories(GXCommon
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>  # used when building in the source tree
-        $<INSTALL_INTERFACE:include>                        # used after 'make install'
+        $<INSTALL_INTERFACE:include/modules>                        # used after 'make install'
 )
 
 target_sources(GXCommon PRIVATE

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMakeLists.txt for GreenX Common Modules, required by all other libs in
 # the package
 
+
 add_library(GXCommon "")
 
 set_target_properties(GXCommon
@@ -12,7 +13,12 @@ set_target_properties(GXCommon
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_Fortran_LIB_DIRECTORY}
         )
 
-target_include_directories(GXCommon PUBLIC src/)
+#target_include_directories(GXCommon PUBLIC src/)
+target_include_directories(GXCommon
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>  # used when building in the source tree
+        $<INSTALL_INTERFACE:include>                        # used after 'make install'
+)
 
 target_sources(GXCommon PRIVATE
         src/kinds.f90
@@ -26,8 +32,10 @@ target_sources(GXCommon PRIVATE
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in the top-level
 # CMakeLists.txt
 install(TARGETS GXCommon
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+    EXPORT greenXTargets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)
 
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in the top-level

--- a/cmake/greenXConfig.cmake
+++ b/cmake/greenXConfig.cmake
@@ -1,0 +1,7 @@
+include(CMakeFindDependencyMacro)
+
+# If greenX depends on other libraries, do:
+find_dependency(BLAS REQUIRED)
+find_dependency(LAPACK REQUIRED)
+# Finally, pull in the targets you exported:
+include("${CMAKE_CURRENT_LIST_DIR}/greenXTargets.cmake")


### PR DESCRIPTION
Added the generation of greenXConfig.cmake and  greenXTargets.cmake files during install (in lib/cmake/greenX) so that commands as find_package(greenX REQUIRED CONFIG) can be used