### PR TITLE
W engine and evaluation of the polarizability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if (${MINIMAX_COMPONENT})
    add_subdirectory(GX-TimeFrequency)
 endif ()
 
-option (LBASIS_COMPONENT "Enable the localized basis component" ON) 
+option (LBASIS_COMPONENT "Enable the localized basis component" OFF) 
 if (${LBASIS_COMPONENT})
    add_subdirectory(GX-LocalizedBasis)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if (${MINIMAX_COMPONENT})
    add_subdirectory(GX-TimeFrequency)
 endif ()
 
-option (LBASIS_COMPONENT "Enable the localized basis component" OFF) 
+option (LBASIS_COMPONENT "Enable the localized basis component" ON) 
 if (${LBASIS_COMPONENT})
    add_subdirectory(GX-LocalizedBasis)
 endif()

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(LibGXLBasis PRIVATE
 	src/separable_ri.f90
         src/localized_basis_types.f90
 	src/localized_basis_environments.f90
+	src/polarizability.f90
 	api/gx_localized_basis.f90
         )
 

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -44,7 +44,7 @@ target_sources(LibGXLBasis PRIVATE
         )
 
 # Link external libraries and lower-level GX lib dependency
-target_link_libraries(LibGXLBasis GXCommon ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+target_link_libraries(LibGXLBasis GXCommon LibGXMiniMax ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
 
 # -----------------------------------------------
 # Library Installation

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(LibGXLBasis PRIVATE
         src/localized_basis_types.f90
 	src/localized_basis_environments.f90
 	src/polarizability.f90
+	src/w_engine.f90
 	api/gx_localized_basis.f90
         )
 

--- a/GX-LocalizedBasis/src/localized_basis_types.f90
+++ b/GX-LocalizedBasis/src/localized_basis_types.f90
@@ -29,7 +29,32 @@ module localized_basis_types
       integer                                    :: n_species
       character, dimension(:), allocatable       :: species
       real(kind=8), dimension(:,:), allocatable  :: coords
-   end type   
+   end type
+
+   type minimax_types
+      integer                                   :: n_points ! number of points
+      real(kind=8), dimension(:,:), allocatable :: cos_tf   ! transformation
+      real(kind=8), dimension(:),   allocatable :: omega    ! frequency points
+      real(kind=8), dimension(:),   allocatable :: tau      ! time points
+      real(kind=8), dimension(:),   allocatable :: weights  ! rpa weights
+   end type minimax_types
+
+   type kohn_sham_types
+      real(kind=8), dimension(:,:,:), allocatable :: wave         ! KS wave function
+      real(kind=8), dimension(:,:),   allocatable :: occupied     ! occ wave function
+      real(kind=8), dimension(:,:),   allocatable :: virtual      ! virt wave function
+      real(kind=8), dimension(:,:,:), allocatable :: eigenvector  ! KS eigenvectors
+      real(kind=8), dimension(:,:),   allocatable :: eigenvalue   ! KS eigenvalues
+   end type kohn_sham_types
+
+   type polarizabily_types
+      real(kind=8), dimension(:,:),   allocatable :: chi_kk         ! Polarizability (r_k)
+      real(kind=8), dimension(:,:),   allocatable :: green_forward  ! Green function (tau)
+      real(kind=8), dimension(:,:),   allocatable :: green_backward ! Green function (-tau)
+      real(kind=8), dimension(:,:),   allocatable :: pi_pq_tau      ! Polarizability (tau)
+      real(kind=8), dimension(:,:,:), allocatable :: pi_pq_omega    ! Polarizability (omega)
+      real(kind=8), dimension(:,:),   allocatable :: rirs_coeff     ! RI-RS Coeff M_{mu k}  
+   end type polarizabily_types
 
    ! Global types
 
@@ -46,5 +71,18 @@ module localized_basis_types
      type(grids_types)                           :: grids
      type(species_types)                         :: species
    end type separable_ri_types
+
+
+   type screened_coulomb_types
+
+      real(kind=8)                                :: error
+      
+      type(minimax_types)                         :: minimax
+      type(kohn_sham_types)                       :: ks
+      type(polarizabily_types)                    :: pi_pq
+
+      real(kind=8), dimension(:,:,:), allocatable :: matrix 
+
+   end type screened_coulomb_types 
 
 end module localized_basis_types

--- a/GX-LocalizedBasis/src/localized_basis_types.f90
+++ b/GX-LocalizedBasis/src/localized_basis_types.f90
@@ -51,8 +51,8 @@ module localized_basis_types
       real(kind=8), dimension(:,:),   allocatable :: chi_kk         ! Polarizability (r_k)
       real(kind=8), dimension(:,:),   allocatable :: green_forward  ! Green function (tau)
       real(kind=8), dimension(:,:),   allocatable :: green_backward ! Green function (-tau)
-      real(kind=8), dimension(:,:),   allocatable :: pi_pq_tau      ! Polarizability (tau)
-      real(kind=8), dimension(:,:,:), allocatable :: pi_pq_omega    ! Polarizability (omega)
+      real(kind=8), dimension(:,:),   allocatable :: tau            ! Polarizability (tau)
+      real(kind=8), dimension(:,:,:), allocatable :: omega          ! Polarizability (omega)
       real(kind=8), dimension(:,:),   allocatable :: rirs_coeff     ! RI-RS Coeff M_{mu k}  
    end type polarizabily_types
 
@@ -79,7 +79,7 @@ module localized_basis_types
       
       type(minimax_types)                         :: minimax
       type(kohn_sham_types)                       :: ks
-      type(polarizabily_types)                    :: pi_pq
+      type(polarizabily_types)                    :: pi
 
       real(kind=8), dimension(:,:,:), allocatable :: matrix 
 

--- a/GX-LocalizedBasis/src/localized_basis_types.f90
+++ b/GX-LocalizedBasis/src/localized_basis_types.f90
@@ -32,11 +32,11 @@ module localized_basis_types
    end type
 
    type minimax_types
-      integer                                   :: n_points ! number of points
-      real(kind=8), dimension(:,:), allocatable :: cos_tf   ! transformation
-      real(kind=8), dimension(:),   allocatable :: omega    ! frequency points
-      real(kind=8), dimension(:),   allocatable :: tau      ! time points
-      real(kind=8), dimension(:),   allocatable :: weights  ! rpa weights
+      integer                                    :: n_points ! number of points
+      real(kind=8), dimension(:,:), allocatable  :: cos_tf   ! transformation
+      real(kind=8), dimension(:),   allocatable  :: omega    ! frequency points
+      real(kind=8), dimension(:),   allocatable  :: tau      ! time points
+      real(kind=8), dimension(:),   allocatable  :: weights  ! rpa weights
    end type minimax_types
 
    type kohn_sham_types
@@ -66,31 +66,40 @@ module localized_basis_types
    ! Global types
 
    type separable_ri_types
-     integer                                     :: n_points
 
-     real(kind=8)                                :: error
+     integer                                      :: n_points
 
-     real(kind=8), dimension(:,:), allocatable   :: ovlp2fn
-     real(kind=8), dimension(:,:), allocatable   :: ovlp3fn
-     real(kind=8), dimension(:,:), allocatable   :: z_coeff
+     real(kind=8)                                 :: error
 
-     type(basis_types)                           :: basis
-     type(grids_types)                           :: grids
-     type(species_types)                         :: species
+     real(kind=8), dimension(:,:), allocatable    :: ovlp2fn
+     real(kind=8), dimension(:,:), allocatable    :: ovlp3fn
+     real(kind=8), dimension(:,:), allocatable    :: z_coeff
+
+     type(basis_types)                            :: basis
+     type(grids_types)                            :: grids
+     type(species_types)                          :: species
+
    end type separable_ri_types
 
    type polarizability_types
  
-      real(kind=8), dimension(:,:),   allocatable :: tau     ! Polarizability (tau)
-      real(kind=8), dimension(:,:,:), allocatable :: omega   ! Polarizability (omega)
+      real(kind=8), dimension(:,:),   allocatable :: tau
+      real(kind=8), dimension(:,:,:), allocatable :: omega
 
-      type(basis_types)                           :: basis
       type(real_space_chi_types)                  :: chi
       type(kohn_sham_types)                       :: ks
       type(minimax_types)                         :: minimax
       type(separable_ri_types)                    :: ri_rs
 
-
    end type polarizability_types
+
+   type w_engine_types
+
+      type(polarizability_types)                  :: pi_pq
+
+     real(kind=8), dimension(:,:,:), allocatable  :: omega
+     real(kind=8), dimension(:,:), allocatable    :: work
+
+   end type w_engine_types
 
 end module localized_basis_types

--- a/GX-LocalizedBasis/src/localized_basis_types.f90
+++ b/GX-LocalizedBasis/src/localized_basis_types.f90
@@ -40,21 +40,28 @@ module localized_basis_types
    end type minimax_types
 
    type kohn_sham_types
-      real(kind=8), dimension(:,:,:), allocatable :: wave         ! KS wave function
+
+      integer                                     :: n_basis     
+      integer                                     :: n_homo
+      integer                                     :: n_lumo
+      integer                                     :: n_occ
+      integer                                     :: n_states
+      integer                                     :: n_spin
+      integer                                     :: n_virt
+      integer                                     :: e_fermi
+
+      real(kind=8), dimension(:,:),   allocatable :: eigenvalues  ! KS eigenvalues
+      real(kind=8), dimension(:,:,:), allocatable :: eigenvectors ! KS eigenvectors
       real(kind=8), dimension(:,:),   allocatable :: occupied     ! occ wave function
       real(kind=8), dimension(:,:),   allocatable :: virtual      ! virt wave function
-      real(kind=8), dimension(:,:,:), allocatable :: eigenvector  ! KS eigenvectors
-      real(kind=8), dimension(:,:),   allocatable :: eigenvalue   ! KS eigenvalues
+      real(kind=8), dimension(:,:,:), allocatable :: wave         ! KS wave function      
    end type kohn_sham_types
 
-   type polarizabily_types
-      real(kind=8), dimension(:,:),   allocatable :: chi_kk         ! Polarizability (r_k)
+   type real_space_chi_types
+      real(kind=8), dimension(:,:),   allocatable :: matrix         ! Polarizability (r_k)
       real(kind=8), dimension(:,:),   allocatable :: green_forward  ! Green function (tau)
       real(kind=8), dimension(:,:),   allocatable :: green_backward ! Green function (-tau)
-      real(kind=8), dimension(:,:),   allocatable :: tau            ! Polarizability (tau)
-      real(kind=8), dimension(:,:,:), allocatable :: omega          ! Polarizability (omega)
-      real(kind=8), dimension(:,:),   allocatable :: rirs_coeff     ! RI-RS Coeff M_{mu k}  
-   end type polarizabily_types
+   end type real_space_chi_types
 
    ! Global types
 
@@ -72,17 +79,18 @@ module localized_basis_types
      type(species_types)                         :: species
    end type separable_ri_types
 
+   type polarizability_types
+ 
+      real(kind=8), dimension(:,:),   allocatable :: tau     ! Polarizability (tau)
+      real(kind=8), dimension(:,:,:), allocatable :: omega   ! Polarizability (omega)
 
-   type screened_coulomb_types
-
-      real(kind=8)                                :: error
-      
-      type(minimax_types)                         :: minimax
+      type(basis_types)                           :: basis
+      type(real_space_chi_types)                  :: chi
       type(kohn_sham_types)                       :: ks
-      type(polarizabily_types)                    :: pi
+      type(minimax_types)                         :: minimax
+      type(separable_ri_types)                    :: ri_rs
 
-      real(kind=8), dimension(:,:,:), allocatable :: matrix 
 
-   end type screened_coulomb_types 
+   end type polarizability_types
 
 end module localized_basis_types

--- a/GX-LocalizedBasis/src/polarizability.f90
+++ b/GX-LocalizedBasis/src/polarizability.f90
@@ -1,0 +1,332 @@
+module polarizability 
+
+  use kinds,                        only: dp
+  use lapack_interfaces,            only: dgemm
+  use localized_basis_environments
+  use separable_ri,                 only: get_rirs_coefficients
+  use gx_minimax,            only: gx_minimax_grid
+  
+
+  implicit none
+
+  contains
+
+  !> brief Compute the irreducible polarizability [PI(iw)]_PQ using 
+  !>       the separable resolution of the identity method   
+  !! @param[in] n_basis: Number of orbital basis (dimension 1 of eigenvectors array) 
+  !! @param[in] n_basis_pairs: Number of orbital basis pairs (dimension 1 of ovlpXfn array)
+  !! @param[in] n_loc_basbas: Number of auxiliary basis fuctions (dimension 2 of ovlp3fn array)
+  !! @param[in] n_rk_points: Number of real-space grid points (dimension 2 of ovlp2fn and
+  !!                         wave arrays )
+  !! @param[in] n_states: Number of Kohn-Sham states (dimension 1 of eingenvalues and wave
+  !!                      arrays  and dimension 2 of the eigenvectors array) 
+  !! param[in] eigenvalues: real array, the Kohn-Shan eigenvalues from the SCF calculation
+  !! param[in] eigenvectors: real array, the Kohn-Sham eigenvectos form the SCF calculation
+  !! param[in] ovlp_2fn: real array, the product of two NAO basis functions
+  !! param[in] ovlp_3fn: real array, the three-center overlap integral over two
+  !!                       NAO basis functions and one auxiliary basis function.
+  !! param[in] wave: real array, the Kohn-Sham wave function in the real-space grid
+  !! param[out] error: real number, maximum error between Coulomb and real-space resolution of
+  !!                   the identity fitting coefficients.          
+  subroutine gx_rirs_polarizability(n_basis, n_basis_pairs, n_basbas, n_rk_points, n_states, &
+                                     eigenvalues, eigenvectors, ovlp2fn, ovlp3fn, wave, error)
+
+   integer                                              :: n_basis, n_basis_pairs, & 
+                                                           n_basbas, n_states, n_rk_points 
+
+   real(kind=dp)                                        :: error
+   real(kind=dp), dimension(n_states)                   :: eigenvalues
+   real(kind=dp), dimension(n_basis, n_states)          :: eigenvectors
+   real(kind=dp), dimension(n_basis_pairs, n_rk_points) :: ovlp2fn
+   real(kind=dp), dimension(n_basis_pairs, n_basbas)    :: ovlp3fn
+   real(kind=dp), dimension(n_states, n_rk_points)      :: wave
+                             
+
+    type(polarizability_types) :: pi_pq
+
+    ! Get the separable RI coefficients 
+    call get_rirs_coefficients(pi_pq%ri_rs, n_basis_pairs, n_basbas, n_rk_points, &
+                               ovlp2fn, ovlp3fn) 
+
+    ! Get the Kohn-Sham wave function in the real-space grid
+    call get_ks_wave(pi_pq, n_basis, n_states, n_rk_points, eigenvalues, & 
+                     eigenvectors, wave)
+                       
+    ! Get minimax time-frequency grid and tranformation matrix from GreenX
+    call get_minimax_grids(pi_pq)
+                       
+    ! Initialize space-time RPA working arrays
+    call initialize_polarizability(pi_pq)
+
+    ! Evaluate the polarizability [pi_PQ](iw)
+    call evaluate_polarizability(pi_pq)    
+    
+    ! Deallocate working arrays
+    call deallocate_polarizability(pi_pq, .true.)
+
+    error=0.d0
+
+  end subroutine gx_rirs_polarizability
+
+  !> brief Compute the irreducible polarizability [PI(iw)]_PQ using 
+  !>       the separable resolution of the identity method
+  !! param[inout] pi_pq: polarizability environment  
+  !! @param[in] n_basis: Number of orbital basis (dimension 1 of eigenvectors array) 
+  !! @param[in] n_rk_points: Number of real-space grid points (dimension of wave arrays )
+  !! @param[in] n_states: Number of Kohn-Sham states (dimension 1 of eingenvalues and wave
+  !!                      arrays  and dimension 2 of the eigenvectors array) 
+  !! param[in] eigenvalues: real array, the Kohn-Shan eigenvalues from the SCF calculation
+  !! param[in] eigenvectors: real array, the Kohn-Sham eigenvectos form the SCF calculation
+  !! param[in] wave: real array, the Kohn-Sham wave function in the real-space grid
+  subroutine get_ks_wave(pi_pq, n_basis, n_states, n_rk_points, & 
+                              eigenvalues, eigenvectors, wave) 
+
+    type(polarizability_types) :: pi_pq
+
+   integer                                              :: n_basis, n_states, n_rk_points    
+          
+    real(kind=dp), dimension(n_states)                   :: eigenvalues
+    real(kind=dp), dimension(n_basis, n_states)          :: eigenvectors
+    real(kind=dp), dimension(n_states, n_rk_points)      :: wave
+
+    ! Initialization 
+    pi_pq%ks%n_basis  = n_basis
+    pi_pq%ks%n_states = n_states
+    pi_pq%ri_rs%n_points = n_rk_points
+
+    call initialize_kohn_sham(pi_pq)
+
+    pi_pq%ks%eigenvalues(:,1)    = eigenvalues(:)
+    pi_pq%ks%eigenvectors(:,:,1) = eigenvectors(:,:)
+    pi_pq%ks%wave(:,:,1)         = wave(:,:)
+
+  end subroutine get_ks_wave
+
+!> brief get frequency-time minimax grids 
+!  param[inout] pi_pq:  polarizability environment
+! **********************************************************************
+  subroutine get_minimax_grids(pi_pq)
+
+    type(polarizability_types)               :: pi_pq
+
+
+    !Local variables
+
+    integer                                   :: info, n_points
+    real(kind=8)                              :: e_tran_max, e_tran_min, duality_error
+    real(kind=8), dimension(3)                :: max_errors
+    real(kind=8), dimension(:),   allocatable :: freq_mesh, freq_weights
+    real(kind=8), dimension(:),   allocatable :: tau_mesh, tau_weights
+    real(kind=8), dimension(:,:), allocatable :: cos_tau_to_freq_weights
+    real(kind=8), dimension(:,:), allocatable :: cos_freq_to_tau_weights
+    real(kind=8), dimension(:,:), allocatable :: sinft_tau_to_freq_weights
+
+    ! Initialization
+
+    call initialize_minimax_grids(pi_pq)
+
+    ! Get the transition energies
+
+    ! call get_minimal_maximal_transition_energy(e_tran_min, e_tran_max)
+      ! Hard coded for now
+      n_points = pi_pq%minimax%n_points
+      e_tran_max = 0.260
+      e_tran_min = 31.725
+
+    if (e_tran_min .le. 0.d0) then
+       call register_exc("Detected metal system, not supported in minimax grid")
+       return
+    end if
+
+    ! Get imaginary time and frequency points and transformations matrices
+
+    call gx_minimax_grid(n_points, e_tran_min, e_tran_max, &
+         tau_mesh, tau_weights, freq_mesh, freq_weights, &
+         cos_tau_to_freq_weights, cos_freq_to_tau_weights, &
+         sinft_tau_to_freq_weights, max_errors, duality_error, info)
+    if (info /= 0) then
+        call register_exc("Error in getting the minimax grid")
+       return
+    end if
+
+    pi_pq%minimax%cos_tf(1: n_points,1: n_points) = cos_tau_to_freq_weights(1: n_points,1: n_points)
+    pi_pq%minimax%omega(1: n_points)= freq_mesh(1: n_points)
+    pi_pq%minimax%tau(1: n_points) = tau_mesh (1: n_points)
+    pi_pq%minimax%weights(1: n_points) = freq_weights(1: n_points)
+
+  end subroutine get_minimax_grids  
+
+  ! ***************************************************************************
+  !> brief Evaluate the polarizability [PI(iw)]_PQ in the auxiliary basis function
+  !! param[inout] pi_pq: polarizability environment    
+  ! ***************************************************************************
+  subroutine evaluate_polarizability (pi_pq) 
+
+    type(polarizability_types) :: pi_pq
+
+    ! Local variables
+    integer i_tau, i_omega
+
+    ! Loop over the imaginary time grid points
+    do i_tau=1, pi_pq%minimax%n_points, 1
+
+       ! Evaluate the polarizability in the real space grid
+       call evaluate_chi(pi_pq, i_tau)
+
+       ! Transform the polarizability form real to auxiliary space
+       call transform_chi_to_pi(pi_pq)
+
+     ! Cosine transform from time to frequency domain
+       do i_omega = 1, pi_pq%minimax%n_points
+          pi_pq%omega(:,:,i_omega) = pi_pq%omega(:,:,i_omega) + &
+                                     pi_pq%tau(:,:)*pi_pq%minimax%cos_tf(i_omega, i_tau)
+       end do ! i_omega
+
+    end do ! i_tau
+
+  end subroutine evaluate_polarizability
+
+  ! ***************************************************************************
+  !> brief Evaluate the polarizability [chi(it)]_kk in the real-space grid
+  !! param[inout] pi_pq: polarizability environment    
+  ! ***************************************************************************  
+  subroutine evaluate_chi(pi_pq, i_tau)
+
+    type(polarizability_types) :: pi_pq
+
+    integer, intent(in)        :: i_tau
+
+   ! Local variables 
+
+    integer                    :: i_point, i_spin, j_point
+    real(kind=dp)              :: tau
+
+    ! Initilization
+
+    tau = pi_pq%minimax%tau(i_tau)
+
+    ! Allocations
+    allocate(pi_pq%chi%matrix(pi_pq%ri_rs%n_points,pi_pq%ri_rs%n_points))    
+
+    do i_spin = 1, pi_pq%ks%n_spin
+
+       call get_green_forward(pi_pq, i_spin, tau)
+
+       call get_green_backward(pi_pq, i_spin, tau) 
+
+    end do
+
+    ! Get the irreducible polarizability chi_0 
+    do j_point = 1, pi_pq%ri_rs%n_points
+       do i_point = 1, pi_pq%ri_rs%n_points
+          pi_pq%chi%matrix(i_point,j_point) = -pi_pq%chi%green_forward(i_point,j_point)* &
+                                               pi_pq%chi%green_backward(i_point,j_point)
+       end do
+    end do
+
+    deallocate(pi_pq%chi%green_forward,pi_pq%chi%green_backward)    
+
+  end subroutine evaluate_chi
+
+  ! ***************************************************************************
+  !> brief Evaluate the forward green function [G(it)]_kk in the real-space grid
+  !! param[inout] pi_pq: polarizability environment    
+  ! *************************************************************************** 
+  subroutine get_green_forward(pi_pq, i_spin, tau)
+
+    type(polarizability_types) :: pi_pq
+
+    integer                    :: i_spin
+    real(kind=dp)              :: tau
+
+
+    ! Local variables
+
+    integer                                    :: i_state
+    real(kind=dp), dimension(:,:), allocatable :: wave_occ
+
+    ! Allocations
+    allocate(pi_pq%chi%green_forward(pi_pq%ri_rs%n_points,pi_pq%ri_rs%n_points))
+    allocate(wave_occ(pi_pq%ri_rs%n_points,pi_pq%ks%n_occ))
+    
+    
+    ! Scale wave function by the eigen energy
+    do i_state = 1, pi_pq%ks%n_occ
+       wave_occ(:, i_state) = pi_pq%ks%wave(:,i_state,i_spin)* &
+               exp(-0.5*tau*(pi_pq%ks%e_fermi - pi_pq%ks%eigenvalues(i_state,i_spin)))
+    end do ! i_state
+
+    ! Get Green function (+tau) = Psi_m(r_k)*Psi_m(r_k)
+    call dgemm("n","t",pi_pq%ri_rs%n_points, pi_pq%ri_rs%n_points, pi_pq%ks%n_occ,1.d0, &
+         wave_occ,pi_pq%ri_rs%n_points,wave_occ,pi_pq%ri_rs%n_points,0.d0,&
+         pi_pq%chi%green_forward,pi_pq%ri_rs%n_points)
+
+    ! Deallocations
+    deallocate(wave_occ)
+
+  end subroutine get_green_forward
+
+  ! ***************************************************************************
+  !> brief Evaluate the backward green function [G(-it)]_kk in the real-space grid
+  !! param[inout] pi_pq: polarizability environment    
+  ! ***************************************************************************  
+  subroutine get_green_backward(pi_pq, i_spin, tau)
+
+    type(polarizability_types) :: pi_pq
+    integer                    :: i_spin
+    real(kind=dp)              :: tau
+
+
+    !Local variables
+    integer                                   :: i_state
+    real(kind=8), dimension(:,:), allocatable :: wave_virt
+
+    ! Allocations 
+    allocate(pi_pq%chi%green_backward(pi_pq%ri_rs%n_points,pi_pq%ri_rs%n_points))    
+    allocate(wave_virt(pi_pq%ri_rs%n_points,pi_pq%ks%n_virt))
+
+    ! Scale the wave function by the eigen energy
+    do i_state = 1 , pi_pq%ks%n_virt
+       wave_virt(:, i_state) = pi_pq%ks%wave(:,pi_pq%ks%n_occ + i_state,i_spin)* &
+                exp(-0.5*tau*(pi_pq%ks%eigenvalues(pi_pq%ks%n_occ + i_state,i_spin) - & 
+                pi_pq%ks%e_fermi))
+    end do
+    
+    ! Get Green function (-tau) = Psi_a(r_k)*Psi_a(r_k')
+    call dgemm("n","t",pi_pq%ri_rs%n_points, pi_pq%ri_rs%n_points, pi_pq%ks%n_virt, 1.d0, &
+         wave_virt,pi_pq%ri_rs%n_points,wave_virt,pi_pq%ri_rs%n_points,0.d0,&
+         pi_pq%chi%green_backward,pi_pq%ri_rs%n_points)
+
+    deallocate (wave_virt)
+
+  end subroutine get_green_backward  
+
+  ! ***************************************************************************
+  !> brief Transform the polarizability [chi(it)]_kk to [pi(it)]_pq 
+  !! param[inout] pi_pq: polarizability environment    
+  ! ***************************************************************************
+  subroutine transform_chi_to_pi(pi_pq)
+
+    type(polarizability_types) :: pi_pq
+
+    ! Local variables
+    real(kind=8), dimension(:,:), allocatable :: mat_aux
+
+    allocate(mat_aux(pi_pq%ri_rs%n_points,pi_pq%ri_rs%basis%n_basbas))
+
+    ! right multiplication [mat_A]_kQ = [chi_0]kk' Z_Qk'
+    call dgemm("n","t",pi_pq%ri_rs%n_points, pi_pq%ri_rs%basis%n_basbas, & 
+               pi_pq%ri_rs%n_points,1.d0, pi_pq%chi%matrix, pi_pq%ri_rs%n_points, &
+               pi_pq%ri_rs%z_coeff, pi_pq%ri_rs%basis%n_basbas,0.d0, & 
+               mat_aux, pi_pq%ri_rs%n_points)
+
+    ! left multiplication [Pi]_PQ = Z_Pk [mat_A]_kQ
+    call dgemm("n","n",pi_pq%ri_rs%basis%n_basbas, pi_pq%ri_rs%basis%n_basbas, & 
+               pi_pq%ri_rs%n_points,1.d0, pi_pq%ri_rs%z_coeff, pi_pq%ri_rs%basis%n_basbas, &
+               mat_aux, pi_pq%ri_rs%n_points,0.d0, pi_pq%tau,pi_pq%ri_rs%basis%n_basbas)
+
+    deallocate(mat_aux)
+
+  end subroutine transform_chi_to_pi
+  
+end module polarizability

--- a/GX-LocalizedBasis/src/separable_ri.f90
+++ b/GX-LocalizedBasis/src/separable_ri.f90
@@ -63,13 +63,15 @@ module separable_ri
   subroutine get_rirs_coefficients(ri_rs, n_basis_pairs,n_loc_basbas,n_rk_points, &
                                     ovlp2fn, ovlp3fn)
 
-   type(separable_ri_types) :: ri_rs
+   type(separable_ri_types)                             :: ri_rs
 
    integer                                              :: n_basis_pairs, n_loc_basbas, n_rk_points
+   logical                                              :: keep_coeff = .true.
 
    real(kind=dp), dimension(n_basis_pairs,n_rk_points)  :: ovlp2fn
    real(kind=dp), dimension(n_basis_pairs,n_loc_basbas) :: ovlp3fn
 
+   ! Initialize separable ri arrays
    call initialization(ri_rs)
 
    ! Copy of the overlap matrix
@@ -78,7 +80,8 @@ module separable_ri
    ! Compute the z coefficients 
    call get_coeff_zrs(ri_rs, n_basis_pairs, n_loc_basbas, ovlp3fn)
 
-   call deallocations(ri_rs,.true.)
+   ! Deallocate separable ri arrays
+   call deallocations(ri_rs, keep_coeff)
 
    end subroutine get_rirs_coefficients
 
@@ -128,20 +131,20 @@ module separable_ri
    allocate(aux_matb(ri_rs%n_points,ri_rs%n_points))
 
    ! Compute A = \sum_ij M_ij^P * D_ij^k'
-   call dgemm('T','N',n_loc_basbas,ri_rs%n_points,n_basis_pairs,1.0d0,&
-              ovlp3fn,n_basis_pairs,ri_rs%ovlp2fn,n_basis_pairs,0.0d0,&
+   call dgemm('T','N',n_loc_basbas,ri_rs%n_points,n_basis_pairs,1.0_dp,&
+              ovlp3fn,n_basis_pairs,ri_rs%ovlp2fn,n_basis_pairs,0.0_dp,&
               aux_mata,n_loc_basbas)
 
    ! Compute B = (sum_ij D_ij^k * D_ij^k')^-1
-   call dgemm('T', 'N',ri_rs%n_points,ri_rs%n_points,n_basis_pairs,1.0d0,&
-              ri_rs%ovlp2fn,n_basis_pairs,ri_rs%ovlp2fn,n_basis_pairs,0.d0,&
+   call dgemm('T', 'N',ri_rs%n_points,ri_rs%n_points,n_basis_pairs,1.0_dp,&
+              ri_rs%ovlp2fn,n_basis_pairs,ri_rs%ovlp2fn,n_basis_pairs,0.0_dp,&
               aux_matb,ri_rs%n_points)
 
-   call power_genmat(aux_matb,ri_rs%n_points,-1.d0, 1.d-10) 
+   call power_genmat(aux_matb,ri_rs%n_points,-1.0_dp, 1.0d-10) 
 
    ! Compute Z = A B^-1
-   call dgemm('N', 'N',n_loc_basbas,ri_rs%n_points,ri_rs%n_points,1.0d0,&
-              aux_mata,n_loc_basbas,aux_matb,ri_rs%n_points,0.d0, &              
+   call dgemm('N', 'N',n_loc_basbas,ri_rs%n_points,ri_rs%n_points,1.0_dp,&
+              aux_mata,n_loc_basbas,aux_matb,ri_rs%n_points,0.0_dp, &              
               ri_rs%z_coeff,n_loc_basbas)
 
    deallocate(aux_mata,aux_matb)

--- a/GX-LocalizedBasis/src/separable_ri.f90
+++ b/GX-LocalizedBasis/src/separable_ri.f90
@@ -53,6 +53,35 @@ module separable_ri
 
    end subroutine gx_rirs_coefficients
 
+  !> brief Compute the least square coefficients (M_Pk) of the separable 
+  !> resolution of the identity for the evaluation of the RPA polarizability   
+  !! param[inout] ri_rs:  Separable resolution-of-the identity environment 
+  !! param[in] ovlp_3fn:  real array, the three-center overlap integral over two
+  !!                       NAO basis functions and one auxiliary basis function.
+  !! @param[in] n_basis_pairs: Number of orbital basis pairs (dimension 1 of ovlp3fn array)
+  !! @param[in] n_loc_basbas: Number of auxiliary basis fuctions (dimension 2 of ovlp3fn array)
+  subroutine get_rirs_coefficients(ri_rs, n_basis_pairs,n_loc_basbas,n_rk_points, &
+                                    ovlp2fn, ovlp3fn)
+
+   type(separable_ri_types) :: ri_rs
+
+   integer                                              :: n_basis_pairs, n_loc_basbas, n_rk_points
+
+   real(kind=dp), dimension(n_basis_pairs,n_rk_points)  :: ovlp2fn
+   real(kind=dp), dimension(n_basis_pairs,n_loc_basbas) :: ovlp3fn
+
+   call initialization(ri_rs)
+
+   ! Copy of the overlap matrix
+   ri_rs%ovlp2fn(:,:) = ovlp2fn(:,:)
+
+   ! Compute the z coefficients 
+   call get_coeff_zrs(ri_rs, n_basis_pairs, n_loc_basbas, ovlp3fn)
+
+   call deallocations(ri_rs,.true.)
+
+   end subroutine get_rirs_coefficients
+
   !> brief Compute the the three-center overlap integral (O_mn^P) using 
   !>        the separable resulution of identity method  
   !! param[inout] ri_rs:  Separable resolution-of-the identity environment 

--- a/GX-LocalizedBasis/src/w_engine.f90
+++ b/GX-LocalizedBasis/src/w_engine.f90
@@ -1,0 +1,103 @@
+! **************************************************************************************************
+!  Copyright (C) 2020-2024 GreenX library
+!  This file is distributed under the terms of the APACHE2 License.
+!
+! **************************************************************************************************
+!> \brief This module contains the subroutines for the localized basis set component of the library
+! ***************************************************************************************************
+
+module w_engine
+
+  use kinds,                        only: dp
+  use lapack_interfaces,            only: dgemm
+  use localized_basis_types,        only: w_engine_types
+  use localized_basis_environments, only: initialize_w_engine, deallocate_w_engine, &
+                                          power_genmat
+  use polarizability,               only: get_rirs_polarizability
+  
+
+
+  implicit none
+
+  contains
+
+  !> brief Compute the screened Coulomb matrix (w engine) in the framework of 
+  !>       the separable resolution of the identity method   
+  !! @param[in] n_basis: Number of orbital basis (dimension 1 of eigenvectors array) 
+  !! @param[in] n_basis_pairs: Number of orbital basis pairs (dimension 1 of ovlpXfn array)
+  !! @param[in] n_loc_basbas: Number of auxiliary basis fuctions (dimension 2 of ovlp3fn array)
+  !! @param[in] n_rk_points: Number of real-space grid points (dimension 2 of ovlp2fn and
+  !!                         wave arrays )
+  !! @param[in] n_states: Number of Kohn-Sham states (dimension 1 of eingenvalues and wave
+  !!                      arrays  and dimension 2 of the eigenvectors array) 
+  !! param[in] eigenvalues: real array, the Kohn-Shan eigenvalues from the SCF calculation
+  !! param[in] eigenvectors: real array, the Kohn-Sham eigenvectos form the SCF calculation
+  !! param[in] ovlp_2fn: real array, the product of two NAO basis functions
+  !! param[in] ovlp_3fn: real array, the three-center overlap integral over two
+  !!                       NAO basis functions and one auxiliary basis function.
+  !! param[in] wave: real array, the Kohn-Sham wave function in the real-space grid
+  !! param[out] error: real number, maximum error between Coulomb and real-space resolution of
+  !!                   the identity fitting coefficients.
+  subroutine gx_w_engine(n_basis, n_basis_pairs, n_basbas, n_rk_points, n_states, &
+                                     eigenvalues, eigenvectors, ovlp2fn, ovlp3fn, wave, error)
+
+    integer                                              :: n_basis, n_basis_pairs, &
+                                                            n_basbas, n_states, n_rk_points
+
+    real(kind=dp)                                        :: error
+    real(kind=dp), dimension(n_states)                   :: eigenvalues
+    real(kind=dp), dimension(n_basis, n_states)          :: eigenvectors
+    real(kind=dp), dimension(n_basis_pairs, n_rk_points) :: ovlp2fn
+    real(kind=dp), dimension(n_basis_pairs, n_basbas)    :: ovlp3fn
+    real(kind=dp), dimension(n_states, n_rk_points)      :: wave
+
+    ! Local variables
+    integer                                              :: i_omega
+
+    type(w_engine_types) :: we                              
+
+    ! Initialize space-time RPA working arrays
+    call initialize_w_engine(we)
+
+    ! Compute the polarizability [pi(iw)]_PQ
+    call get_rirs_polarizability(we%pi_pq, n_basis, n_basis_pairs, n_basbas, n_rk_points, &
+                                 n_states, eigenvalues, eigenvectors, ovlp2fn, ovlp3fn, wave)
+
+    do i_omega=1, we%pi_pq%minimax%n_points
+
+       ! Get correlation part of the screened coulomb interaction
+       call get_screened_coulomb(we, i_omega) 
+
+    end do ! i_omega
+    
+       ! Deallocate working arrays
+    call deallocate_w_engine(we)
+
+    error = 0.0_dp
+
+  end  subroutine gx_w_engine
+
+  subroutine get_screened_coulomb(we, i_omega)
+
+    type(w_engine_types)                       :: we
+
+    integer                                    :: i_omega
+
+    ! Local variables
+    real(kind=dp), allocatable, dimension(:,:) :: work
+
+    ! Compute [1-pi(iw)]_PQ
+    we%omega(:, :, i_omega) = we%work(:, :) - we%pi_pq%omega(:, :, i_omega)
+
+    ! Compute 1/[1-pi(iw)]_PQ
+    call power_genmat(we%omega, we%pi_pq%ri_rs%basis%n_basbas, -1.0_dp, 1.0d-10)
+
+    ! Compute correlation part of the screened Coulomb interaction
+    we%omega(:, :, i_omega) = we%omega(:, :, i_omega) - we%work(:, :)
+
+    ! Deallocation    
+    deallocate(work)
+    
+  end subroutine get_screened_coulomb
+
+end module w_engine

--- a/GX-common/src/lapack_interfaces.f90
+++ b/GX-common/src/lapack_interfaces.f90
@@ -36,12 +36,11 @@ module lapack_interfaces
      end subroutine dgesdd
   end interface
 
-  !interface num_prec
-  !   real(kind=dp) function dlamch(cmach)
-  !     implicit none             
-  !     character(len=1), intent(in) :: cmach
-  !   end function dlamch 
-  !end interface
+  interface presicion
+     double precision function dlamch(cmach)
+       character(len=1), intent(in) :: cmach
+     end function dlamch 
+  end interface
 
   interface diag
      subroutine dsyevx(jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, &
@@ -57,5 +56,17 @@ module lapack_interfaces
        real(kind=dp), intent(inout) :: a(lda, *), w(*), work(*), z(ldz,*)
      end subroutine dsyevx
   end interface
+
+  interface unitary
+     subroutine dlaset(uplo, m, n, alpha, beta, a, lda) 
+       use kinds, only: dp
+
+       character(len=1), intent(in) :: uplo
+       integer, intent(in)          :: m, n, lda
+       real(kind=dp), intent(in)    :: alpha, beta
+       real(kind=dp), intent(in)    :: a(lda, *)
+     end subroutine dlaset
+
+  end interface unitary
 
 end module lapack_interfaces 


### PR DESCRIPTION
In this pull request, I have implemented the computation of the polarizability, $\chi_0(i\omega)$, using the auxiliary basis functions, $P(\mathbf{r})$, within the framework of the space-time and separable resolution-of-the-identity-approaches. The evaluation of $[\chi_0(i\omega)]_{PQ}$ can be utilized for both the low-scaling random phase approximation and the GW method. Additionally, for the GW method, I have introduced the W engine, which computes the screened Coulomb interaction, $W$, from the polarizability.