### PR TITLE
Fix GX-AC failing tests when GMP library is disabled

### DIFF
--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -118,26 +118,30 @@ add_test(
         COMMAND pytest -s test_gx_analytic_continuation_greedy_64bit.py --build-dir ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
 )
-add_test(
-        NAME test_gx_analytic_continuation_no-greedy_128bit
-        COMMAND pytest -s test_gx_analytic_continuation_no-greedy_128bit.py --build-dir ${CMAKE_BINARY_DIR}
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
-)
-add_test(
-        NAME test_gx_analytic_continuation_greedy_128bit
-        COMMAND pytest -s test_gx_analytic_continuation_greedy_128bit.py --build-dir ${CMAKE_BINARY_DIR}
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
-)
+if(GMPXX_FOUND)
+        add_test(
+                NAME test_gx_analytic_continuation_no-greedy_128bit
+                COMMAND pytest -s test_gx_analytic_continuation_no-greedy_128bit.py --build-dir ${CMAKE_BINARY_DIR}
+                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
+        )
+        add_test(
+                NAME test_gx_analytic_continuation_greedy_128bit
+                COMMAND pytest -s test_gx_analytic_continuation_greedy_128bit.py --build-dir ${CMAKE_BINARY_DIR}
+                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
+        )
+endif()
 add_test(
         NAME test_gx_analytic_continuation_symmetry_64bit
         COMMAND pytest -s test_gx_analytic_continuation_symmetry_64bit.py --build-dir ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
 )
-add_test(
-        NAME test_gx_analytic_continuation_symmetry_128bit
-        COMMAND pytest -s test_gx_analytic_continuation_symmetry_128bit.py --build-dir ${CMAKE_BINARY_DIR}
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
-)
+if(GMPXX_FOUND)
+        add_test(
+                NAME test_gx_analytic_continuation_symmetry_128bit
+                COMMAND pytest -s test_gx_analytic_continuation_symmetry_128bit.py --build-dir ${CMAKE_BINARY_DIR}
+                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/${TEST_TARGET_DIR}
+        )
+endif()
 add_test(
         NAME test_gx_analytic_continuation_reference_0
         COMMAND pytest -s test_gx_analytic_continuation_reference_0.py --build-dir ${CMAKE_BINARY_DIR}

--- a/GX-AnalyticContinuation/README.md
+++ b/GX-AnalyticContinuation/README.md
@@ -80,7 +80,7 @@ python plot.py output.dat comparison.png
 The figure is saved as `comparison.png`. Feel free to change some parameters in the `pade_example.f90` script and compile again to see how it is affecting the pade interpolation.
 
 ## Running the regression tests 
-Regression tests of the GX-AC component use the testing framework [pytest](https://docs.pytest.org/en/stable/#). Simply type `ctest` in the build directory after the GreenX library has been build.
+Regression tests of the GX-AC component use the testing framework [pytest](https://docs.pytest.org/en/stable/#). Simply type `ctest` in the build directory after the GreenX library has been build. Note that if you link against the GMP libaray (`-DENABLE_GNU_GMP=ON`), additional regression tests will run that test the behaviour of the AC component in combination with GMP.
 
 For more information please refer to the main [README.md](https://github.com/nomad-coe/greenX/blob/main/README.md) of this repository.
 


### PR DESCRIPTION
**Issue:** regression tests that rely on the GMP library are run even if linking against the GMP library is disabled 
regression tests that rely on GMP are: 
- test_gx_analytic_continuation_no-greedy_128bit
- test_gx_analytic_continuation_greedy_128bit
- test_gx_analytic_continuation_symmetry_128bit

the expected behaviour would be that only if GMP is linked again GreenX those regression tests are run 

**Solution:** regression tests that rely on GMP are now disabled if GMP is not linked 

Thanks a lot to @mailhexu for pointing this out in Issue #156 
