### PR TITLE
cmake build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,11 @@
 cmake_minimum_required(VERSION 3.15.0)
 
 project(greenX
-  LANGUAGES Fortran
-  VERSION 0.0.1
+  LANGUAGES Fortran CXX
+  VERSION 2.2
+  DESCRIPTION "Library for Many-body Green Functions on HPC"
+  HOMEPAGE_URL "https://nomad-coe.github.io/greenX/"
 )
-
-# Need for Intel MKL and for GNU GMP
-enable_language(CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -23,8 +22,23 @@ set(CMAKE_Fortran_BIN_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_Fortran_LIB_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
 
+# Set installation location
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(default_install_prefix "${PROJECT_SOURCE_DIR}/install")
+  set(CMAKE_INSTALL_PREFIX ${default_install_prefix}
+    CACHE STRING "Choose the installation directory. Default location is ${default_install_prefix}"
+    FORCE)
+endif()
+
 # Define GNU standard installation directories
 include(GNUInstallDirs)
+
+# the set the include directory where the mod files will be installed. the include directory is compiler dependent.
+if(NOT DEFINED CMAKE_INSTALL_Fortran_MODULES)
+  set(CMAKE_INSTALL_Fortran_MODULES
+      "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}"
+  )
+endif()
 
 # CMake module directory
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
@@ -124,7 +138,7 @@ if (${COMPILE_SUBMODULES})
   set(IDieL_INSTALL_DIR "${IDieL_SOURCE}/IDieL")
   install(FILES ${IDieL_INSTALL_DIR}/lib/libIDieL.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
   install(DIRECTORY ${IDieL_INSTALL_DIR}/include/
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/modules/
+        DESTINATION ${CMAKE_INSTALL_Fortran_MODULES}
         FILES_MATCHING PATTERN "*d")
   else()
     message(FATAL_ERROR "IDieL source directory not found: ${IDieL_SOURCE}. You can obtain it by executing 'git submodule update --init'.")
@@ -148,7 +162,7 @@ if (${PAW_COMPONENT})
    install(FILES ${LIBPAW_INSTALL_DIR}/lib/libabinit_common.a DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
    install(FILES ${LIBPAW_INSTALL_DIR}/lib/libpaw.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
    install(DIRECTORY ${LIBPAW_INSTALL_DIR}/include/
-           DESTINATION ${CMAKE_INSTALL_PREFIX}/include/modules/
+           DESTINATION ${CMAKE_INSTALL_Fortran_MODULES}
            FILES_MATCHING PATTERN "*d")
 endif()
 
@@ -174,10 +188,22 @@ install(
     EXPORT      greenXTargets
     NAMESPACE   greenX::
     FILE        greenXTargets.cmake
-    DESTINATION lib/cmake/greenX
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/greenX"
+)
+
+configure_file("${PROJECT_SOURCE_DIR}/cmake/greenXConfig.cmake.in"
+               "${PROJECT_BINARY_DIR}/greenXConfig.cmake" @ONLY)
+
+install(
+    FILES "${PROJECT_BINARY_DIR}/greenXConfig.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/greenX"
 )
 
 install(
-    FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/greenXConfig.cmake"
-    DESTINATION lib/cmake/greenX
+  FILES "${PROJECT_SOURCE_DIR}/cmake/Findzofu.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/greenX"
+)
+install(
+  FILES "${PROJECT_SOURCE_DIR}/cmake/FindGMPXX.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/greenX"
 )

--- a/GX-AnalyticContinuation/CMakeLists.txt
+++ b/GX-AnalyticContinuation/CMakeLists.txt
@@ -21,13 +21,13 @@ set_target_properties(LibGXAC
 target_include_directories(LibGXAC
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include/modules>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_Fortran_MODULES}/AnalyticContinuation/modules>
 )
 if(GMPXX_FOUND)
   add_definitions(-DGMPXX_FOUND)
   target_sources(LibGXAC PRIVATE src/pade_approximant.f90 src/ComplexGMP.cpp src/Symmetry_pade.cpp src/pade_mp.cpp api/gx_ac.F90)
   target_include_directories(LibGXAC PRIVATE ${GMPXX_INCLUDE_DIRS})
-  target_link_libraries(LibGXAC GXCommon ${GMPXX_LIBRARIES} gmp)
+  target_link_libraries(LibGXAC GXCommon greenX::gmpxx)
 else()
   target_sources(LibGXAC PRIVATE src/pade_approximant.f90 api/gx_ac.F90)
   target_link_libraries(LibGXAC GXCommon)
@@ -42,7 +42,7 @@ install(TARGETS LibGXAC EXPORT greenXTargets ARCHIVE DESTINATION lib LIBRARY DES
 
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
-install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}  DESTINATION include)
+install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}  DESTINATION ${CMAKE_INSTALL_Fortran_MODULES}/AnalyticContinuation)
 
 
 

--- a/GX-LocalizedBasis/CMakeLists.txt
+++ b/GX-LocalizedBasis/CMakeLists.txt
@@ -32,13 +32,13 @@ target_include_directories(LibGXLBasis
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
 
         # Install-time includes (point to the location where headers/modules land when installed)
-        $<INSTALL_INTERFACE:include/modules>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_Fortran_MODULES}/LocalizedBasis/modules>
 )
 
 # Define source that comprise LibGXLBasis
 target_sources(LibGXLBasis PRIVATE
 	src/separable_ri.f90
-        src/localized_basis_types.f90
+    src/localized_basis_types.f90
 	src/localized_basis_environments.f90
 	src/polarizability.f90
 	src/w_engine.f90
@@ -62,7 +62,7 @@ install(TARGETS LibGXLBasis
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
-        DESTINATION include)
+        DESTINATION ${CMAKE_INSTALL_Fortran_MODULES}/LocalizedBasis)
 
 # -----------------------------------------------
 # Application Testing Set-Up

--- a/GX-TimeFrequency/CMakeLists.txt
+++ b/GX-TimeFrequency/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(LibGXMiniMax
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utilities>
 
         # Install-time includes (point to the location where headers/modules land when installed)
-        $<INSTALL_INTERFACE:include/modules>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_Fortran_MODULES}/TimeFrequency/modules>
 )
 # Define source that comprise LibGXMiniMax
 target_sources(LibGXMiniMax PRIVATE
@@ -82,7 +82,7 @@ install(TARGETS LibGXMiniMax
 # Install modules
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in top-level CMake
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
-        DESTINATION include)
+        DESTINATION ${CMAKE_INSTALL_Fortran_MODULES}/TimeFrequency)
 
 # Install `Build utility` program
 install(TARGETS GXTabulateGrids

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -17,7 +17,7 @@ set_target_properties(GXCommon
 target_include_directories(GXCommon
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>  # used when building in the source tree
-        $<INSTALL_INTERFACE:include/modules>                        # used after 'make install'
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_Fortran_MODULES}/common/modules>                        # used after 'make install'
 )
 
 target_sources(GXCommon PRIVATE
@@ -41,7 +41,7 @@ install(TARGETS GXCommon
 # Destination relative to ${CMAKE_INSTALL_PREFIX}, defined in the top-level
 ## CMakeLists.txt
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
-        DESTINATION include)
+        DESTINATION ${CMAKE_INSTALL_Fortran_MODULES}/common)
 
 
 # ensure that zofu is build before GXCommon 

--- a/cmake/FindGMPXX.cmake
+++ b/cmake/FindGMPXX.cmake
@@ -3,19 +3,37 @@
 #  GMPXX_FOUND
 #  GMPXX_INCLUDE_DIR
 #  GMPXX_LIBRARIES
-
-find_path(GMPXX_INCLUDE_DIR NAMES gmpxx.h)
-find_library(GMPXX_LIBRARY NAMES gmpxx)
-
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GMPXX DEFAULT_MSG GMPXX_INCLUDE_DIR GMPXX_LIBRARY)
+find_package(PkgConfig)
 
-if(GMPXX_FOUND)
-  set(GMPXX_INCLUDE_DIRS ${GMPXX_INCLUDE_DIR})
-  set(GMPXX_LIBRARIES ${GMPXX_LIBRARY})
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(GREENX_GMPXX IMPORTED_TARGET GLOBAL gmpxx)
+  pkg_check_modules(GREENX_GMP IMPORTED_TARGET GLOBAL gmp)
+endif()
+if(NOT GREENX_GMP_FOUND)
+  find_path(GREENX_GMPXX_INCLUDE_DIR NAMES gmpxx.h)
+  find_library(GREENX_GMPXX_LIBRARY NAMES gmpxx)
+  find_library(GREENX_GMP_LIBRARY NAMES gmp)
 else()
-  set(GMPXX_INCLUDE_DIRS)
-  set(GMPXX_LIBRARIES)
+  set(GREENX_GMP_LIBRARY ${GREENX_GMP_LINK_LIBRARIES})
+  set(GREENX_GMPXX_LIBRARY ${GREENX_GMPXX_LINK_LIBRARIES})
+  set(GREENX_GMPXX_INCLUDE_DIR ${GREENX_GMP_INCLUDE_DIRS})
+endif()
+
+find_package_handle_standard_args(GMPXX DEFAULT_MSG GREENX_GMPXX_INCLUDE_DIRS GREENX_GMPXX_LIBRARY GREENX_GMP_LIBRARY)
+
+set(GREENX_GMPXX_LIBRARIES ${GREENX_GMPXX_LIBRARY} ${GREENX_GMP_LIBRARY})
+
+if (NOT TARGET greenX::gmpxx)
+  add_library(greenX::gmpxx INTERFACE IMPORTED)
+  set_target_properties(greenX::gmpxx
+                        PROPERTIES
+                        INTERFACE_LINK_LIBRARIES "${GREENX_GMPXX_LIBRARIES}")
+  if (GREENX_GMPXX_INCLUDE_DIRS)
+    set_target_properties(greenX::gmpxx
+                          PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${GREENX_GMPXX_INCLUDE_DIRS})
+  endif()
 endif()
 
 mark_as_advanced(GMPXX_INCLUDE_DIR GMPXX_LIBRARY)

--- a/cmake/greenXConfig.cmake.in
+++ b/cmake/greenXConfig.cmake.in
@@ -3,5 +3,10 @@ include(CMakeFindDependencyMacro)
 # If greenX depends on other libraries, do:
 find_dependency(BLAS REQUIRED)
 find_dependency(LAPACK REQUIRED)
+
+if(@ENABLE_GNU_GMP@)
+   find_dependency(GMPXX)
+endif()
+
 # Finally, pull in the targets you exported:
 include("${CMAKE_CURRENT_LIST_DIR}/greenXTargets.cmake")


### PR DESCRIPTION
This PR contains various improvements to the cmake build system. 

- Add the missing `GMP` targets when `find_package(greenX)` is called
- Namespace the `include` directory for the `fortran` modules
- generate the `greenXconfig.cmake` file 