### PR TITLE
Fix potential name clash when used as dependency  

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip3 install cmake
 
       - name: Install python dependencies
-        run: pip3 install numpy pytest
+        run: pip3 install numpy "pytest<9"
 
       - name: Install blas, lapack and other dependencies
         run: sudo apt-get install libblas-dev liblapack-dev doxygen libgmp10 libgmpxx4ldbl libgmp-dev libopenblas-dev

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.9.24'
+          python-version: '3.10.20'
 
       - name: Install Cmake
         run: pip3 install cmake

--- a/GX-AnalyticContinuation/api/gx_ac.F90
+++ b/GX-AnalyticContinuation/api/gx_ac.F90
@@ -29,7 +29,7 @@
 !!   PHYSICAL REVIEW B 94, 165109 (2016);
 !!   J. CHEM. THEORY COMPUT. 19, 16, 5450–5464 (2023)
 module gx_ac
-   use kinds, only: dp
+   use gx_kinds, only: dp
    use, intrinsic :: iso_c_binding, only: c_int, c_double_complex, c_ptr
    use pade_approximant, only: evaluate_thiele_pade, thiele_pade, c_zero, c_one
    implicit none

--- a/GX-AnalyticContinuation/src/pade_approximant.f90
+++ b/GX-AnalyticContinuation/src/pade_approximant.f90
@@ -6,7 +6,7 @@
 
 !>  Fortran double precision implementation of the thiele pade approximation. 
 module pade_approximant
-   use kinds, only: dp
+   use gx_kinds, only: dp
    implicit none
 
    private

--- a/GX-LocalizedBasis/src/localized_basis_environments.f90
+++ b/GX-LocalizedBasis/src/localized_basis_environments.f90
@@ -7,7 +7,7 @@
 ! ***************************************************************************************************
 module localized_basis_environments
 
-   use kinds,                 only: dp
+   use gx_kinds,                 only: dp
    use error_handling,        only: register_exc   
    use localized_basis_types, only: separable_ri_types, &
                                     polarizability_types, &

--- a/GX-LocalizedBasis/src/polarizability.f90
+++ b/GX-LocalizedBasis/src/polarizability.f90
@@ -7,7 +7,7 @@
 ! ***************************************************************************************************
 module polarizability 
 
-  use kinds,                        only: dp
+  use gx_kinds,                        only: dp
   use error_handling,               only: register_exc  
   use lapack_interfaces,            only: dgemm
   use localized_basis_types,        only: polarizability_types

--- a/GX-LocalizedBasis/src/separable_ri.f90
+++ b/GX-LocalizedBasis/src/separable_ri.f90
@@ -7,7 +7,7 @@
 ! ***************************************************************************************************
 module separable_ri
 
-   use kinds,                        only: dp
+   use gx_kinds,                        only: dp
    use lapack_interfaces,            only: dgemm  
    use localized_basis_types,        only: separable_ri_types
    use localized_basis_environments, only: calculate_error, power_genmat, &

--- a/GX-LocalizedBasis/src/w_engine.f90
+++ b/GX-LocalizedBasis/src/w_engine.f90
@@ -8,7 +8,7 @@
 
 module w_engine
 
-  use kinds,                        only: dp
+  use gx_kinds,                        only: dp
   use lapack_interfaces,            only: dgemm
   use localized_basis_types,        only: w_engine_types
   use localized_basis_environments, only: initialize_w_engine, deallocate_w_engine, &

--- a/GX-LocalizedBasis/test/test_gx_localized_basis.f90
+++ b/GX-LocalizedBasis/test/test_gx_localized_basis.f90
@@ -6,7 +6,7 @@
 
 program test_gx_localized_basis
 
-   use kinds,                           only: dp        
+   use gx_kinds,                           only: dp        
    use gx_localized_basis,              only: gx_rirs_coefficients
 
    implicit none

--- a/GX-PAW/common/src/17_minimax/minimax_grids.F90
+++ b/GX-PAW/common/src/17_minimax/minimax_grids.F90
@@ -22,7 +22,7 @@ module minimax_grids
 #include "gx_common.h"
   use defs_basis,        only: dp, pi
   use m_errors
-  !use kinds,             only: dp
+  !use gx_kinds,             only: dp
   !use error_handling,    only: register_exc
   !use gx_constants,         only: pi
   use minimax_tau,       only: get_points_weights_tau

--- a/GX-PAW/common/src/17_minimax/minimax_grids.F90
+++ b/GX-PAW/common/src/17_minimax/minimax_grids.F90
@@ -24,7 +24,7 @@ module minimax_grids
   use m_errors
   !use kinds,             only: dp
   !use error_handling,    only: register_exc
-  !use constants,         only: pi
+  !use gx_constants,         only: pi
   use minimax_tau,       only: get_points_weights_tau
   use minimax_omega,     only: get_points_weights_omega
   use minimax_utils,     only: cosine_wt, cosine_tw, sine_tw

--- a/GX-PAW/common/src/17_minimax/minimax_omega.F90
+++ b/GX-PAW/common/src/17_minimax/minimax_omega.F90
@@ -19,7 +19,7 @@ module minimax_omega
 #include "gx_common.h"
   use defs_basis,     only: dp
   use m_errors
-  !use kinds,          only: dp
+  !use gx_kinds,          only: dp
   !use error_handling, only: register_exc
   use minimax_utils,  only: er_aw_aux
   implicit none

--- a/GX-PAW/common/src/17_minimax/minimax_tau.F90
+++ b/GX-PAW/common/src/17_minimax/minimax_tau.F90
@@ -19,7 +19,7 @@ module minimax_tau
 #include "gx_common.h"
   use defs_basis,     only: dp
   use m_errors
-  !use kinds,          only: dp
+  !use gx_kinds,          only: dp
   !use error_handling, only: register_exc
   use minimax_utils,  only: er_aw_aux
   implicit none

--- a/GX-PAW/common/src/17_minimax/minimax_utils.F90
+++ b/GX-PAW/common/src/17_minimax/minimax_utils.F90
@@ -13,7 +13,7 @@ module minimax_utils
 #include "gx_common.h"
   use defs_basis,     only: dp
   use m_errors
-  !use kinds, only: dp
+  !use gx_kinds, only: dp
   implicit none
 
   private

--- a/GX-TimeFrequency/src/minimax_grids.F90
+++ b/GX-TimeFrequency/src/minimax_grids.F90
@@ -17,7 +17,7 @@ module minimax_grids
 #include "gx_common.h"
   use kinds,             only: dp
   use error_handling,    only: register_exc
-  use constants,         only: pi
+  use gx_constants,      only: pi
   use minimax_tau,       only: get_points_weights_tau
   use minimax_omega,     only: get_points_weights_omega
   use minimax_utils,     only: cosine_wt, cosine_tw, sine_tw, sine_wt

--- a/GX-TimeFrequency/src/minimax_grids.F90
+++ b/GX-TimeFrequency/src/minimax_grids.F90
@@ -15,7 +15,7 @@
 
 module minimax_grids
 #include "gx_common.h"
-  use kinds,             only: dp
+  use gx_kinds,             only: dp
   use error_handling,    only: register_exc
   use gx_constants,      only: pi
   use minimax_tau,       only: get_points_weights_tau

--- a/GX-TimeFrequency/src/minimax_omega.F90
+++ b/GX-TimeFrequency/src/minimax_omega.F90
@@ -13,7 +13,7 @@
 ! ***************************************************************************************************
 module minimax_omega
 #include "gx_common.h"
-  use kinds,          only: dp
+  use gx_kinds,          only: dp
   use error_handling, only: register_exc
   use minimax_utils,  only: er_aw_aux
   implicit none

--- a/GX-TimeFrequency/src/minimax_tau.F90
+++ b/GX-TimeFrequency/src/minimax_tau.F90
@@ -13,7 +13,7 @@
 ! ***************************************************************************************************
 module minimax_tau
 #include "gx_common.h"
-  use kinds,          only: dp
+  use gx_kinds,          only: dp
   use error_handling, only: register_exc
   use minimax_utils,  only: er_aw_aux
   implicit none

--- a/GX-TimeFrequency/src/minimax_utils.F90
+++ b/GX-TimeFrequency/src/minimax_utils.F90
@@ -7,7 +7,7 @@
 ! ***************************************************************************************************
 module minimax_utils
 #include "gx_common.h"
-  use kinds, only: dp
+  use gx_kinds, only: dp
   implicit none
 
   private

--- a/GX-TimeFrequency/test/test_gx_minimax_duality_error.f90
+++ b/GX-TimeFrequency/test/test_gx_minimax_duality_error.f90
@@ -9,7 +9,7 @@
 
 program test_gx_minimax_duality_error
 
-    use kinds,      only: dp
+    use gx_kinds,      only: dp
     use gx_minimax, only: gx_minimax_grid, tau_npoints_supported
 
     implicit none

--- a/GX-TimeFrequency/test/test_gx_minimax_grid.f90
+++ b/GX-TimeFrequency/test/test_gx_minimax_grid.f90
@@ -8,7 +8,7 @@
 !> Cannot write python bindings as all grids/weights are allocated in the library
 !> - This should be changed
 program test_gx_minimax_grid
-    use kinds, only: dp
+    use gx_kinds, only: dp
     use gx_minimax, only: gx_minimax_grid
     implicit none
 

--- a/GX-TimeFrequency/utilities/gx_tabulate_minimax.F90
+++ b/GX-TimeFrequency/utilities/gx_tabulate_minimax.F90
@@ -9,7 +9,7 @@ program gx_tabulate_minimax
 #include "gx_common.h"
 
     use iso_fortran_env, only : std_out => output_unit
-    use kinds,           only : dp
+    use gx_kinds,           only : dp
     use gx_constants,       only:  ch10
     use gx_minimax,      only : gx_minimax_grid, gx_get_error_message, tau_npoints_supported
 

--- a/GX-TimeFrequency/utilities/gx_tabulate_minimax.F90
+++ b/GX-TimeFrequency/utilities/gx_tabulate_minimax.F90
@@ -10,7 +10,7 @@ program gx_tabulate_minimax
 
     use iso_fortran_env, only : std_out => output_unit
     use kinds,           only : dp
-    use constants,       only:  ch10
+    use gx_constants,       only:  ch10
     use gx_minimax,      only : gx_minimax_grid, gx_get_error_message, tau_npoints_supported
 
     implicit none

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(GXCommon
 )
 
 target_sources(GXCommon PRIVATE
-        src/kinds.f90
+        src/gx_kinds.f90
         src/gx_constants.f90
         src/unit_conversion.f90
         src/error_handling.f90

--- a/GX-common/CMakeLists.txt
+++ b/GX-common/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(GXCommon
 
 target_sources(GXCommon PRIVATE
         src/kinds.f90
-        src/constants.f90
+        src/gx_constants.f90
         src/unit_conversion.f90
         src/error_handling.f90
         src/lapack_interfaces.f90

--- a/GX-common/src/error_handling.f90
+++ b/GX-common/src/error_handling.f90
@@ -1,5 +1,7 @@
 module error_handling
-   use constants, only: ch10, err_len
+
+   use gx_constants, only: ch10, err_len
+
    implicit none
    private
 

--- a/GX-common/src/gx_constants.f90
+++ b/GX-common/src/gx_constants.f90
@@ -11,7 +11,7 @@
 !> (Web Version 8.0). Database developed by J. Baker, M. Douma, and S. Kotochigova.
 !> Available at http://physics.nist.gov/constants,
 !> National Institute of Standards and Technology, Gaithersburg, MD 20899.
-module constants
+module gx_constants
     use kinds, only: dp
     implicit none
     private
@@ -23,4 +23,4 @@ module constants
     !> Arbitrary error length
     integer, parameter, public :: err_len = 1024
 
-end module constants
+end module gx_constants

--- a/GX-common/src/gx_constants.f90
+++ b/GX-common/src/gx_constants.f90
@@ -12,7 +12,7 @@
 !> Available at http://physics.nist.gov/constants,
 !> National Institute of Standards and Technology, Gaithersburg, MD 20899.
 module gx_constants
-    use kinds, only: dp
+    use gx_kinds, only: dp
     implicit none
     private
 

--- a/GX-common/src/gx_kinds.f90
+++ b/GX-common/src/gx_kinds.f90
@@ -1,5 +1,5 @@
 !> Precision constants
-module kinds
+module gx_kinds
    implicit none
 
    !> Single precision
@@ -11,4 +11,4 @@ module kinds
    !> Long length character
    integer, parameter, public :: long_char = 200
 
-end module kinds
+end module gx_kinds

--- a/GX-common/src/lapack_interfaces.f90
+++ b/GX-common/src/lapack_interfaces.f90
@@ -11,7 +11,7 @@ module lapack_interfaces
 
   interface blas3
      subroutine dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
-       use kinds, only: dp
+       use gx_kinds, only: dp
        implicit none
        integer                      :: len
        character(len=1), intent(in) :: transa, transb
@@ -24,7 +24,7 @@ module lapack_interfaces
 
   interface svd
      subroutine dgesdd(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, iwork, info)
-       use kinds, only: dp
+       use gx_kinds, only: dp
        implicit none
        integer                      :: len
        character(len=1), intent(in) :: jobz
@@ -45,7 +45,7 @@ module lapack_interfaces
   interface diag
      subroutine dsyevx(jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, &
                             m, w, z, ldz, work, lwork, iwork, ifail, info) 
-       use kinds, only: dp     
+       use gx_kinds, only: dp     
        implicit none
        character(len=1), intent(in) :: jobz, range, uplo
        integer, intent(in)          :: il, iu, lda, ldz, lwork, m, n
@@ -59,7 +59,7 @@ module lapack_interfaces
 
   interface unitary
      subroutine dlaset(uplo, m, n, alpha, beta, a, lda) 
-       use kinds, only: dp
+       use gx_kinds, only: dp
 
        character(len=1), intent(in) :: uplo
        integer, intent(in)          :: m, n, lda

--- a/GX-common/src/unit_conversion.f90
+++ b/GX-common/src/unit_conversion.f90
@@ -13,7 +13,7 @@
 !> National Institute of Standards and Technology, Gaithersburg, MD 20899.
 !
 module unit_conversion
-    use kinds, only: dp 
+    use gx_kinds, only: dp 
     implicit none
     private
 


### PR DESCRIPTION
- modules "kinds" and "constants" are commen in other builds
- if greenX is a dependency then this could create conflicts in the build
- renamed the modules "gx_kinds" and "gx_constants"

Aditionally: updated the python version so that the CI works again